### PR TITLE
print_response: resolve `sys.stdout` only when we use it

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -144,8 +144,11 @@ class CommandLineTool(object):
             single_item=False,
             header=True,
             csv=False,
-            file=sys.stdout):  # pylint: disable=redefined-builtin
+            file=None):  # pylint: disable=redefined-builtin
         """print request response in chosen format"""
+        if file is None:
+            file = sys.stdout
+
         if format is not None:
             for item in result:
                 print(format.format(**item), file=file)

--- a/aiven/client/pretty.py
+++ b/aiven/client/pretty.py
@@ -104,8 +104,8 @@ def print_table(
         drop_fields=None,
         table_layout=None,
         header=True,
-        file=sys.stdout):  # pylint: disable=redefined-builtin
+        file=None):  # pylint: disable=redefined-builtin
     """print a list of dicts in a nicer table format"""
     for row in yield_table(result, drop_fields=drop_fields, table_layout=table_layout,
                            header=header):
-        print(row, file=file)
+        print(row, file=file or sys.stdout)


### PR DESCRIPTION
This makes overriding sys.stdout in mocks, etc work.