### PR TITLE
git dcli: for user_config's only support two levels of settings

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -896,7 +896,7 @@ class AivenCLI(argx.CommandLineTool):
                 raise argx.UserError("Invalid value {!r}: {}".format(key_value, ex))
 
             conf = user_config
-            parts = key.split(".")
+            parts = key.split(".", 1)
             for part in parts[:-1]:
                 conf.setdefault(part, {})
                 conf = conf[part]


### PR DESCRIPTION
Previously it was not possible to set a two level config option
that had a dot in its name.

This is because the code tried to support unlimited levels of
JSON nesting even though all Aiven user_config values have at
most a single level of nesting.