### PR TITLE
Show help message for relevant level

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -190,7 +190,7 @@ class CommandLineTool(object):
             expected_errors.extend(ext.expected_errors())
             ext.config = self.config
         try:
-            return self.run_actual()
+            return self.run_actual(args)
         except tuple(expected_errors) as ex:  # pylint: disable=catching-non-exception
             # nicer output on "expected" errors
             err = "command failed: {0.__class__.__name__}: {0}".format(ex)
@@ -200,10 +200,10 @@ class CommandLineTool(object):
             self.log.error("*** terminated by keyboard ***")
             return 2
 
-    def run_actual(self):
+    def run_actual(self, args_for_help):
         func = getattr(self.args, "func", None)
         if not func:
-            self.parser.print_help()
+            self.parser.parse_args(args_for_help + ["--help"])
             return 1
 
         self.pre_run(func)


### PR DESCRIPTION
This does not change output for 'avn', 'avn user info' or
'avn unknown-command-here'.

After:

```
$ avn user
usage: avn user [-h] {create,info,login,tokens-expire} ...

positional arguments:
  {create,info,login,tokens-expire}
    create              Create a user
    info                Show current user info
    login               Login as a user
    tokens-expire       Expire all authorization tokens

optional arguments:
  -h, --help            show this help message and exit
```
------
Before:

```
$ avn user
usage: avn [-h] [--config CONFIG] [--auth-ca FILE] [--auth-token AUTH_TOKEN]
           [--show-http] [--url URL]
           ...

optional arguments:
  -h, --help            show this help message and exit
  --config CONFIG       config file location
                        '...'
  --auth-ca FILE        CA certificate to use [AIVEN_CA_CERT], default None
  --auth-token AUTH_TOKEN
                        Client auth token to use [AIVEN_AUTH_TOKEN],
                        [AIVEN_CREDENTIALS_FILE]
  --show-http           Show HTTP requests and responses
  --url URL             Server base url default '...'

command categories:

    card                Card commands
    cloud               Cloud commands
    credits             Credits commands
    events              View project event logs
    logs                View project logs
    project             Project commands
    service             Service commands
    user                User commands
    vpc                 Vpc commands
```