### PR TITLE
auth: Support new APIs for managing individual access tokens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,10 +147,6 @@ View project management event log::
 
   $ avn events
 
-View project service log entries::
-
-  $ avn logs -n 100
-
 Services
 --------
 List services (of the active project)::
@@ -176,6 +172,10 @@ Full service information in json, as it is returned by the Aiven REST API::
 Only a specific field in the output, custom formatting::
 
   $ avn service list db1 --format "The service is at {service_uri}"
+
+View service log entries (most recent entries and keep on following logs, other options can be used to get history)::
+
+  $ avn service logs db1 -f
 
 Launching services
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,10 @@ Login::
 
   $ avn user login <your@email>
 
+Logout (revokes current access token, other sessions remain valid)::
+
+  $ avn user logout
+
 Expire all authentication tokens for your user, logs out all web console sessions, etc.
 You will need to login again after this.::
 

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,17 @@ You will need to login again after this.::
 
  $ avn user tokens-expire
 
+Manage individual access tokens::
+
+ $ avn user access-token list
+ $ avn user access-token create --description <usage_description> [--max-age-seconds <secs>] [--extend-when-used]
+ $ avn user access-token update <token|token_prefix> --description <new_description>
+ $ avn user access-token revoke <token|token_prefix>
+
+Note that the system has hard limits for the number of tokens you can create. If you're
+permanently done using a token you should always use ``user access-token revoke`` operation
+to revoke the token so that it does not count towards the quota.
+
 Clouds
 ------
 List available cloud regions::

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -150,6 +150,12 @@ class AivenCLI(argx.CommandLineTool):
         else:
             self.log.info("No projects exists. You should probably create one with 'avn project create <name>'")
 
+    @arg()
+    def user_logout(self):
+        """Logout from current session"""
+        self.client.access_token_revoke(token_prefix=self._get_auth_token())
+        self._remove_auth_token_file()
+
     @arg.verbose
     def user_tokens_expire(self):
         """Expire all authorization tokens"""
@@ -1598,8 +1604,7 @@ ssl.truststore.type=JKS
         self.log.info("Aiven credentials written to: %s", aiven_credentials_filename)
 
     def _open_auth_token_file(self, mode="r"):
-        default_token_file_path = os.path.join(envdefault.AIVEN_CONFIG_DIR, "aiven-credentials.json")
-        auth_token_file_path = (os.environ.get("AIVEN_CREDENTIALS_FILE") or default_token_file_path)
+        auth_token_file_path = self._get_auth_token_file_name()
         try:
             return open(auth_token_file_path, mode)
         except IOError as ex:
@@ -1609,6 +1614,16 @@ ssl.truststore.type=JKS
                 os.chmod(aiven_dir, 0o700)
                 return open(auth_token_file_path, mode)
             raise
+
+    def _remove_auth_token_file(self):
+        try:
+            os.unlink(self._get_auth_token_file_name())
+        except OSError:
+            pass
+
+    def _get_auth_token_file_name(self):
+        default_token_file_path = os.path.join(envdefault.AIVEN_CONFIG_DIR, "aiven-credentials.json")
+        return os.environ.get("AIVEN_CREDENTIALS_FILE") or default_token_file_path
 
     def _get_auth_token(self):
         token = self.args.auth_token

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -464,6 +464,7 @@ class AivenCLI(argx.CommandLineTool):
         self.print_response(service, format=self.args.format, json=self.args.json,
                             table_layout=layout, single_item=True)
 
+    @optional_auth
     @arg.project
     @arg.service_name
     @arg("arg", nargs="*",
@@ -473,6 +474,8 @@ class AivenCLI(argx.CommandLineTool):
         if "://" in self.args.name:
             url = self.args.name
         else:
+            if not self.client.auth_token:
+                raise argx.UserError("not authenticated: please login first with 'avn user login'")
             service = self.client.get_service(project=self.get_project(), service=self.args.name)
             url = service["service_uri"]
 


### PR DESCRIPTION
Previously only login and expire all access tokens were supported.
New APIs have since been added to support listing, creating, updating
and revoking individual access tokens.