### PR TITLE
tasks: add support for upgrade_check

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -997,6 +997,24 @@ ssl.truststore.type=JKS
 
     @arg.project
     @arg.service_name
+    @arg("--operation", help="Task operation", choices=["upgrade_check"], default="upgrade_check")
+    @arg("--target_version", help="Upgrade target version", choices=["9.5", "9.6", "10"])
+    @arg("--format", help="Format string for output, e.g. '{name} {retention_hours}'")
+    @arg.json
+    def service_task_create(self):
+        """Create a service task"""
+        response = self.client.create_service_task(
+            project=self.get_project(),
+            service=self.args.name,
+            operation=self.args.operation,
+            target_version=self.args.target_version
+        )
+        self.print_response([response["task"]], format=self.args.format, json=self.args.json,
+                            table_layout=["task_type", "success"])
+        print(response["task"]["result"])
+
+    @arg.project
+    @arg.service_name
     @arg.topic
     @arg.partitions
     @arg.replication

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -296,6 +296,16 @@ class AivenClient(AivenClientBase):
     def delete_service_integration(self, project, integration_id):
         return self.verify(self.delete, "/project/{}/integration/{}".format(project, integration_id))
 
+    def create_service_task(self, project, service, operation, target_version):
+        return self.verify(self.post, "/project/{}/service/{}/task".format(project, service), body={
+            "task_type": operation,
+            "target_version": target_version,
+        })
+
+    def get_service_task(self, project, service, task_id):
+        return self.verify(self.get, "/project/{}/service/{}/task/{}".format(project, service, task_id),
+                           result_key="task")
+
     def get_service_topic(self, project, service, topic):
         return self.verify(self.get, "/project/{}/service/{}/topic/{}".format(project, service, topic),
                            result_key="topic")


### PR DESCRIPTION
Initial user of this will be Aiven PostgreSQL upgrade check
but other uses for the tasks concept will follow as well.