### PR TITLE
makefile: use python2-pylint and python3-pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ clean:
 	$(RM) -r rpms
 
 build-dep-fedora:
-	sudo dnf install -y pylint python-devel python-flake8 python3-requests python2-requests \
-		tar rpmdevtools python2-pylint
+	sudo dnf install -y --best --allowerasing python-devel python-flake8 python3-requests python2-requests \
+		tar rpmdevtools python2-pylint python3-pylint
 
 rpm: $(generated)
 	git archive --prefix=aiven-client/ HEAD -o rpm-src-aiven-client.tar


### PR DESCRIPTION
Using "pylint" may cause undesireable package downgrades when pylint
versions newer than in Fedora are available.