### PR TITLE
Support easier read replica creation and upcoming API

### DIFF
--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -399,12 +399,13 @@ class AivenClient(AivenClientBase):
         return self.verify(self.delete, url)
 
     def create_service(self, project, service, service_type, group_name, plan,
-                       cloud=None, user_config=None, project_vpc_id=UNDEFINED):
+                       cloud=None, user_config=None, project_vpc_id=UNDEFINED, service_integrations=None):
         user_config = user_config or {}
         body = {
             "group_name": group_name,
             "cloud": cloud,
             "plan": plan,
+            "service_integrations": service_integrations,
             "service_name": service,
             "service_type": service_type,
             "user_config": user_config,


### PR DESCRIPTION
`service create` command supports --read-replica-for parameter, which
can be used to indicate that the service being created should be a
read replica of the given service. This automatically sets the
appropriate user configuration options for PostgreSQL services and for
other services that use the upcoming read_replica service integration
API that is defined instead.