### PR TITLE
argx: avoid outputting a stacktrace when output file is closed

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -226,9 +226,14 @@ class CommandLineTool:  # pylint: disable=old-style-class
             err = "command failed: {0.__class__.__name__}: {0}".format(ex)
             self.log.error(err)
             return 1
+        except OSError as ex:
+            if ex.errno != errno.EPIPE:
+                raise
+            self.log.error("*** output truncated ***")
+            return 13  # SIGPIPE value in case anyone cares
         except KeyboardInterrupt:
             self.log.error("*** terminated by keyboard ***")
-            return 2
+            return 2  # SIGINT
 
     def run_actual(self, args_for_help):
         func = getattr(self.args, "func", None)


### PR DESCRIPTION
Interrupting `avn .. | less` would previously generate a long, ugly
traceback.  This commit instead generates a simple "output truncated"
message, similar to the one we generate on KeyboardInterrupt.