### PR TITLE
Fixed service types -v with list of dicts

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -434,9 +434,6 @@ class AivenCLI(argx.CommandLineTool):
                 else:
                     for name, spec in sorted(options.items()):
                         default = spec.get("default")
-                        if isinstance(default, list):
-                            default = ",".join(default)
-
                         default_desc = "(default={!r})".format(default) if default is not None else ""
                         description = ": {}".format(spec["description"]) if "description" in spec else ""
                         types = spec["type"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,5 +24,9 @@ def test_service_plans():
     AivenCLI().run(args=["service", "plans"])
 
 
+def test_service_types_v():
+    AivenCLI().run(args=["service", "types", "-v"])
+
+
 def test_help():
     AivenCLI().run(args=["help"])


### PR DESCRIPTION
service types -v had slightly prettified printing of list of default
entries.  As it was, all it really did was strip some "s from lists,
but break on dicts. Just calling repr on the whole thing by default is
probably sensible, as even that output matches with what
e.g. json/Python do by default.