### PR TITLE
Make table prettyprinter handle datetime & decimal types better

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -14,8 +14,6 @@ except ImportError:
 import aiven.client.client
 import argparse
 import csv as csvlib
-import datetime
-import decimal
 import errno
 import json as jsonlib
 import logging
@@ -25,18 +23,6 @@ import sys
 
 ARG_LIST_PROP = "_arg_list"
 LOG_FORMAT = "%(levelname)s\t%(message)s"
-
-
-class CustomJsonEncoder(jsonlib.JSONEncoder):
-    def default(self, o):  # pylint:disable=E0202
-        if isinstance(o, (datetime.datetime, datetime.date)):
-            return o.isoformat()
-        if isinstance(o, datetime.timedelta):
-            return str(o)
-        if isinstance(o, decimal.Decimal):
-            return str(o)
-
-        return jsonlib.JSONEncoder.default(self, o)
 
 
 class CustomFormatter(argparse.RawDescriptionHelpFormatter):
@@ -198,7 +184,7 @@ class CommandLineTool:  # pylint: disable=old-style-class
             for item in result:
                 print(format.format(**item), file=file)
         elif json:
-            print(jsonlib.dumps(result, indent=4, sort_keys=True, cls=CustomJsonEncoder), file=file)
+            print(jsonlib.dumps(result, indent=4, sort_keys=True, cls=pretty.CustomJsonEncoder), file=file)
         elif csv:
             fields = []
             for field in table_layout:

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -1,0 +1,25 @@
+# Copyright 2019, Aiven, https://aiven.io/
+#
+# This file is under the Apache License, Version 2.0.
+# See the file `LICENSE` for details.
+from aiven.client.pretty import format_item
+import pytest
+import datetime
+import decimal
+
+
+pytestmark = [pytest.mark.unittest, pytest.mark.all]
+
+
+@pytest.mark.parametrize("value,expected", [
+    (1, "1"),
+    ("a_string", "a_string"),
+    (datetime.datetime(year=2019, month=12, day=23), "2019-12-23T00:00:00"),
+    ([datetime.datetime(year=2019, month=12, day=23)], "2019-12-23T00:00:00"),
+    (["x", datetime.datetime(year=2019, month=12, day=23)], "x, 2019-12-23T00:00:00"),
+    (decimal.Decimal("64.23"), "64.23"),
+    ({"a": decimal.Decimal("12.34"), "b": datetime.datetime(year=2019, month=12, day=23)},
+     '{"a": "12.34", "b": "2019-12-23T00:00:00"}')
+])
+def test_format_item(value, expected):
+    assert format_item(None, value) == expected


### PR DESCRIPTION
format_item() was not able to format Decimal objects, and had
trouble with dicts containing decimal or datetime values. Use our
custom JSON encoder in a couple more places to make it more tolerant.

Also add some test cases.