### PR TITLE
Drop python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "pypy3"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "pypy3"
-
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 
 install:
   - "pip install flake8 pylint pytest requests"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 short_ver = 2.3.1
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 generated = aiven/client/version.py
-PYTHON ?= python
+PYTHON ?= python3
 PYTHON_DIRS = aiven tests
 
 all: $(generated)
@@ -28,8 +28,8 @@ clean:
 	$(RM) -r rpms
 
 build-dep-fedora:
-	sudo dnf install -y --best --allowerasing python-devel python-flake8 python3-requests python2-requests \
-		tar rpmdevtools python2-pylint python3-pylint
+	sudo dnf install -y --best --allowerasing python3-devel python3-flake8 python3-requests \
+		tar rpmdevtools python3-pylint
 
 rpm: $(generated)
 	git archive --prefix=aiven-client/ HEAD -o rpm-src-aiven-client.tar

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Platform requirements
 =====================
 
 Aiven Client has been tested and developed on Linux and Mac OS X systems.
-It is a Python program that works with Python 2.7 or 3.4 or newer versions.
+It is a Python program that works with Python 3.4 or newer versions.
 The only external dependency is Requests_ (and certifi_ on Windows/OSX).
 
 .. _`Requests`: http://www.python-requests.org/
@@ -59,11 +59,11 @@ Installation
 
 From PyPI (Linux/OSX)::
 
-  $ python -m pip install aiven-client
+  $ python3 -m pip install aiven-client
 
 From PyPI (Windows)::
 
-  c:\> python -m pip install aiven-client
+  c:\> python3 -m pip install aiven-client
 
 Build an RPM package (Linux)::
 
@@ -72,7 +72,7 @@ Build an RPM package (Linux)::
 Basic Usage
 ===========
 
-* NOTE: On Windows you may need to use ``python -m aiven.client`` instead of ``avn``.
+* NOTE: On Windows you may need to use ``python3 -m aiven.client`` instead of ``avn``.
 * All commands will output the raw REST API JSON response with ``--json``
 
 Help command

--- a/aiven-client.spec
+++ b/aiven-client.spec
@@ -1,9 +1,3 @@
-%if %{?python3_sitelib:1}0
-%global use_python3 1
-%else
-%global use_python3 0
-%endif
-
 Name:           aiven-client
 Version:        %{major_version}
 Release:        %{minor_version}%{?dist}
@@ -12,13 +6,8 @@ Summary:        Aiven Client
 License:        ASL 2.0
 Source0:        rpm-src-aiven-client.tar
 BuildArch:      noarch
-%if %{use_python3}
 Requires:       python3-requests
 BuildRequires:  python3-devel, python3-flake8, python3-pylint, python3-pytest
-%else
-Requires:       python-requests
-BuildRequires:  python-devel, python-flake8, pylint, pytest
-%endif
 
 
 %description
@@ -35,34 +24,20 @@ aiven-client (`avn`) is the official command-line client for Aiven.
 
 %install
 %{__mkdir_p} %{buildroot}%{_bindir}
-%if %{use_python3}
-sed -e 's,$PYTHON,python3,g' scripts/avn > %{buildroot}%{_bindir}/avn
 %{__mkdir_p} %{buildroot}%{python3_sitelib}
 cp -a aiven %{buildroot}%{python3_sitelib}/
-%else
-sed -e 's,$PYTHON,python,g' scripts/avn > %{buildroot}%{_bindir}/avn
-%{__mkdir_p} %{buildroot}%{python_sitelib}
-cp -a aiven %{buildroot}%{python_sitelib}/
-%endif
+cp scripts/avn %{buildroot}%{_bindir}/avn
 chmod 755 %{buildroot}%{_bindir}/avn
 
 
 %check
-%if %{use_python3}
-make test PYTHON=python3
-%else
-make test PYTHON=python2
-%endif
+make test
 
 
 %files
 %defattr(-,root,root,-)
 %doc LICENSE README.rst
-%if %{use_python3}
 %{python3_sitelib}/aiven
-%else
-%{python_sitelib}/aiven
-%endif
 %{_bindir}/avn
 
 

--- a/scripts/avn
+++ b/scripts/avn
@@ -1,4 +1,4 @@
-#! /usr/bin/env $PYTHON
+#! /usr/bin/env python3
 from aiven.client.cli import AivenCLI
 
 AivenCLI().main()

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/version.py
+++ b/version.py
@@ -3,7 +3,7 @@ automatically maintains the latest git tag + revision info in a python file
 
 """
 
-import imp
+import importlib
 import os
 import subprocess
 
@@ -11,7 +11,7 @@ import subprocess
 def get_project_version(version_file):
     version_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), version_file)
     try:
-        module = imp.load_source("verfile", version_file)
+        module = importlib.load_module(version_file)
         file_ver = module.__version__
     except:  # pylint: disable=bare-except
         file_ver = None


### PR DESCRIPTION
Python2 end-of-life is 1st of January 2020. Old versions of aiven-client continue to work for users with no access to python3.