### PR TITLE
Make updating Kafka connector configuration more convenient

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1568,11 +1568,18 @@ ssl.truststore.type=JKS
     @arg.project
     @arg.service_name
     @arg.connector_name
+    @arg("--fetch-current", action="store_true", help="Fetch current config first, and use as a base for update")
     @arg.json_path_or_string("connector_config")
     def service__connector__update(self):
         """Update a Kafka connector"""
         project_name = self.get_project()
-        self.client.update_kafka_connector(project_name, self.args.name, self.args.connector, self.args.connector_config)
+        self.client.update_kafka_connector(
+            project_name,
+            self.args.name,
+            self.args.connector,
+            self.args.connector_config,
+            self.args.fetch_current,
+        )
 
     @arg.project
     @arg.service_name


### PR DESCRIPTION
When reconfiguring a Kafka connector with 'avn service connector update',
the new configuration dict had to contain all mandatory config properties
for the connector, even if their values would not change. This made changing
individual options less convenient than it could have been.

Add a new --fetch-current option for the update command. When given,
client will first fetch the connector's current configuration, and then
update it with the given changes, freeing the user from needing to include
any options that don't need to change.