### PR TITLE
Enable travis builds for multiple operating systems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,104 @@ python:
   - "3.8"
   - "pypy3"
 
-install:
-  - "pip install flake8 pylint pytest requests isort"
+os:
+  # Linux is the default platform for development.
+  - linux
 
+jobs:
+  include:
+    # Ensure we only run linters once.
+    - stage: lint
+      python: 3.8
+      os: linux
+      name: Style
+      script:
+        - pip install -r requirements.dev.txt
+        - "make validate-style"
+
+    - stage: lint
+      python: 3.8
+      os: linux
+      name: Flake8
+      script:
+        - pip install -r requirements.dev.txt
+        - make flake8
+
+    - stage: lint
+      python: 3.8
+      os: linux
+      name: PyLint
+      script:
+        - pip install -r requirements.dev.txt
+        - make pylint
+
+    # MacOS we want to ensure system-python is working properly
+    # macOS 10.13
+    - stage: test
+      os: osx
+      osx_image: xcode10.1
+      language: generic
+    # macOS 10.14.x
+    - stage: test
+      os: osx
+      osx_image: xcode11.3
+      language: generic
+    # macOS 10.15.x
+    - stage: test
+      os: osx
+      osx_image: xcode12
+      language: generic
+
+    # Windows jobs have very specific requirements
+    - stage: test
+      os: windows
+      python: 3.6
+      language: shell
+      before_install:
+        - choco install python --version 3.6
+        - export PYTHON=python
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
+    - stage: test
+      os: windows
+      python: 3.7
+      language: shell
+      before_install:
+        - choco install python --version 3.7
+        - export PYTHON=python
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    - stage: test
+      os: windows
+      python: 3.8
+      language: shell
+      before_install:
+        - choco install python --version 3.8
+        - export PYTHON=python
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+
+before_install:
+  - export PYTHON=python3
+  # Setup TLS certificates for requests
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      /usr/bin/security find-certificate -a -p /System/Library/Keychains/SystemRootCertificates.keychain > cert.pem
+      export REQUESTS_CA_BUNDLE="$(pwd)/cert.pem"
+    fi
+
+install:
+  # Install the package to bring in dependencies.
+  - $PYTHON --version
+  - $PYTHON -m pip --version
+  - $PYTHON -m pip install pytest
+  - $PYTHON -m pip install -e .
+
+
+stages:
+  - lint
+  - test
+
+# Don't use the Makefile since it won't work on Windows without a lot of effort.
 script:
-  - "make flake8"
-  - "make pylint"
-  - "make pytest"
-  - "make validate-style"
+  - $PYTHON -m pytest -vv tests/

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,5 @@
+flake8
+pylint
+pytest
+# Lock isort version since pylint fails with the 5.x series at the moment.
+isort<5.0


### PR DESCRIPTION
Update `.travis.yml` to execute the Python test suite on all supported operating systems. Linter checks are configured to run as a separate stage and only on Linux since they should be OS-independent.

isort is version locked below the 5.x series since it is incompatible with the 5.x series it seems.
