### PR TITLE
Add the yapf code formatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,4 @@
 [flake8]
 max-line-length = 125
+# These codes tend to disagree with yapf
+ignore = E129,W503

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,6 @@
 [MESSAGES CONTROL]
 disable=
+    bad-continuation,
     bad-option-value,
     duplicate-code,
     fixme,

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,55 @@
+[style]
+# For docs, see https://github.com/google/yapf/blob/master/README.rst
+
+based_on_style = pep8
+# Disallow splitting between dict key and dict value in multiline {"key": "value"} lines
+ALLOW_SPLIT_BEFORE_DICT_VALUE = false
+
+# Avoid adding unnecessary blank lines when nesting
+BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = false
+
+# Always add two blank lines for top-level classes and methods
+BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION = 2
+
+# These two combine consecutive ({ and }) to same line to reduce clutter
+COALESCE_BRACKETS = true
+DEDENT_CLOSING_BRACKETS = true
+
+# Line length
+COLUMN_LIMIT = 125
+
+# Try to avoid having overly long lines by having excessively large penalty for that.
+SPLIT_PENALTY_EXCESS_CHARACTER = 1000000000
+
+# Always split dict entries to one entry per line
+# EACH_DICT_ENTRY_ON_SEPARATE_LINE = true
+
+# Never split this comment to a separate line. Workaround for certain flake8 & email template lines
+I18N_COMMENT = # noqa
+
+# Allow automatically joining lines, for example, multiline if that would fit to a single line
+JOIN_MULTIPLE_LINES = true
+
+# "3 * 5", instead of "3*5"
+SPACES_AROUND_POWER_OPERATOR = true
+
+# Follow normal comment style by adding two spaces between code and comment
+SPACES_BEFORE_COMMENT = 2
+
+# If list of items is comma terminated, always split to one per line.
+SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED = true
+
+# Related to previous one, if list of items (args or dict/list/...) needs to be split, split to one per line.
+# SPLIT_ALL_COMMA_SEPARATED_VALUES = true
+
+# Split dict generators for clarity (add line breaks between { and key: val etc.
+SPLIT_BEFORE_DICT_SET_GENERATOR = true
+
+# Split method(k1=v1, k2=v2...) to separate lines
+SPLIT_BEFORE_NAMED_ASSIGNS = true
+
+# For complex (for some definition of complex) comprehensions, put output, for and if to separate lines
+SPLIT_COMPLEX_COMPREHENSION = true
+
+# When splitting something to multiple lines ('method(\n val...'), intend by 4
+CONTINUATION_INDENT_WIDTH = 4

--- a/.yapfignore
+++ b/.yapfignore
@@ -1,0 +1,10 @@
+.eggs
+.git
+.hg
+.mypy_cache
+.tox
+.venv
+_build
+buck-out
+build
+dist

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test: flake8 pylint pytest
 
 reformat:
 	$(PYTHON) -m isort --recursive $(PYTHON_DIRS)
+	yapf --parallel --recursive --in-place .
 
 validate-style:
 	$(eval CHANGES_BEFORE := $(shell mktemp))

--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -18,6 +18,7 @@ import sys
 # Optional shell completions
 try:
     import argcomplete  # pylint: disable=import-error
+
     ARGCOMPLETE_INSTALLED = True
 except ImportError:
     ARGCOMPLETE_INSTALLED = False
@@ -27,22 +28,23 @@ try:
 except ImportError:
     __version__ = "UNKNOWN"
 
-
 ARG_LIST_PROP = "_arg_list"
 LOG_FORMAT = "%(levelname)s\t%(message)s"
 
 
 class CustomFormatter(argparse.RawDescriptionHelpFormatter):
     """Help formatter to display the default value only for integers and non-empty strings"""
+
     def _get_help_string(self, action):
         help_text = action.help
-        if '%(default)' not in action.help and action.default is not argparse.SUPPRESS:
-            if action.option_strings or action.nargs in [argparse.OPTIONAL, argparse.ZERO_OR_MORE]:
-                if (
-                        (not isinstance(action.default, bool) and isinstance(action.default, int))
-                        or (isinstance(action.default, str) and action.default)
-                ):
-                    help_text += ' (default: %(default)s)'
+        if "%(default)" not in action.help and action.default is not argparse.SUPPRESS:
+            if action.option_strings or action.nargs in [
+                argparse.OPTIONAL,
+                argparse.ZERO_OR_MORE,
+            ]:
+                if (not isinstance(action.default, bool)
+                    and isinstance(action.default, int)) or (isinstance(action.default, str) and action.default):
+                    help_text += " (default: %(default)s)"
         return help_text
 
 
@@ -61,6 +63,7 @@ def arg(*args, **kwargs):
             arg_list.insert(0, (args, kwargs))
 
         return func
+
     return wrap
 
 
@@ -79,8 +82,9 @@ class Config(dict):
             if ex.errno == errno.ENOENT:
                 return
 
-            raise UserError("Failed to load configuration file {!r}: {}: {}".format(
-                self.file_path, ex.__class__.__name__, ex))
+            raise UserError(
+                "Failed to load configuration file {!r}: {}: {}".format(self.file_path, ex.__class__.__name__, ex)
+            )
         except ValueError:
             raise UserError("Invalid JSON in configuration file {!r}".format(self.file_path))
 
@@ -102,11 +106,13 @@ class CommandLineTool:  # pylint: disable=old-style-class
         self._cats = {}
         self._extensions = []
         self.parser = argparse.ArgumentParser(prog=name, formatter_class=CustomFormatter)
-        self.parser.add_argument("--config", help="config file location %(default)r",
-                                 default=envdefault.AIVEN_CLIENT_CONFIG)
-        self.parser.add_argument('--version', action='version', version='aiven-client {}'.format(__version__))
-        self.subparsers = self.parser.add_subparsers(title="command categories", dest="command",
-                                                     help="", metavar="")
+        self.parser.add_argument(
+            "--config",
+            help="config file location %(default)r",
+            default=envdefault.AIVEN_CLIENT_CONFIG,
+        )
+        self.parser.add_argument("--version", action="version", version="aiven-client {}".format(__version__))
+        self.subparsers = self.parser.add_subparsers(title="command categories", dest="command", help="", metavar="")
         self.args = None
 
     def add_cmd(self, func):
@@ -130,7 +136,8 @@ class CommandLineTool:  # pylint: disable=old-style-class
                 parser = subparsers.add_parser(
                     cat[-1],
                     help=" ".join(cat).title() + " commands",
-                    formatter_class=CustomFormatter)
+                    formatter_class=CustomFormatter,
+                )
                 self._cats[cat] = parser.add_subparsers()
             subparsers = self._cats[cat]
 
@@ -177,16 +184,17 @@ class CommandLineTool:  # pylint: disable=old-style-class
         return []
 
     def print_response(
-            self,
-            result,
-            json=True,
-            format=None,  # pylint: disable=redefined-builtin
-            drop_fields=None,
-            table_layout=None,
-            single_item=False,
-            header=True,
-            csv=False,
-            file=None):  # pylint: disable=redefined-builtin
+        self,
+        result,
+        json=True,
+        format=None,  # pylint: disable=redefined-builtin
+        drop_fields=None,
+        table_layout=None,
+        single_item=False,
+        header=True,
+        csv=False,
+        file=None,
+    ):  # pylint: disable=redefined-builtin
         """print request response in chosen format"""
         if file is None:
             file = sys.stdout
@@ -195,7 +203,10 @@ class CommandLineTool:  # pylint: disable=old-style-class
             for item in result:
                 print(format.format(**item), file=file)
         elif json:
-            print(jsonlib.dumps(result, indent=4, sort_keys=True, cls=pretty.CustomJsonEncoder), file=file)
+            print(
+                jsonlib.dumps(result, indent=4, sort_keys=True, cls=pretty.CustomJsonEncoder),
+                file=file,
+            )
         elif csv:
             fields = []
             for field in table_layout:
@@ -213,17 +224,26 @@ class CommandLineTool:  # pylint: disable=old-style-class
             if single_item:
                 result = [result]
 
-            pretty.print_table(result, drop_fields=drop_fields, table_layout=table_layout,
-                               header=header, file=file)
+            pretty.print_table(
+                result,
+                drop_fields=drop_fields,
+                table_layout=table_layout,
+                header=header,
+                file=file,
+            )
 
     def run(self, args=None):
         args = args or sys.argv[1:]
         if not args:
-            args = ['--help']
+            args = ["--help"]
 
         self.parse_args(args=args)
         self.config = Config(self.args.config)
-        expected_errors = [requests.exceptions.ConnectionError, UserError, aiven.client.client.Error]
+        expected_errors = [
+            requests.exceptions.ConnectionError,
+            UserError,
+            aiven.client.client.Error,
+        ]
         for ext in self._extensions:  # note: _extensions includes self
             expected_errors.extend(ext.expected_errors())
             ext.config = self.config

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -21,13 +21,22 @@ def get_json_config(path_or_string):
 
 def json_path_or_string(param_name):
     def wrapper(fun):
-        arg(param_name, help="JSON string or path (preceded by '@') to a JSON configuration file")(fun)
+        arg(
+            param_name,
+            help="JSON string or path (preceded by '@') to a JSON configuration file",
+        )(fun)
 
         @wraps(fun)
         def wrapped(self):
-            setattr(self.args, param_name, get_json_config(getattr(self.args, param_name, "")))
+            setattr(
+                self.args,
+                param_name,
+                get_json_config(getattr(self.args, param_name, "")),
+            )
             return fun(self)
+
         return wrapped
+
     return wrapper
 
 
@@ -35,7 +44,10 @@ arg.account_id = arg("account_id", help="Account identifier")
 arg.authentication_id = arg("authentication_id", help="Account authentication method identifier")
 arg.billing_address = arg("--billing-address", help="Physical billing address for invoices")
 arg.billing_currency = arg("--billing-currency", help="Currency for charges")
-arg.billing_extra_text = arg("--billing-extra-text", help="Extra text to include in invoices (e.g. cost center id)")
+arg.billing_extra_text = arg(
+    "--billing-extra-text",
+    help="Extra text to include in invoices (e.g. cost center id)",
+)
 arg.card_id = arg("--card-id", help="Card ID")
 arg.cloud = arg("--cloud", help="Cloud to use (see 'cloud list' command)")
 arg.config_cmdline = arg(
@@ -44,7 +56,7 @@ arg.config_cmdline = arg(
     metavar="KEY=VALUE",
     action="append",
     default=[],
-    help="Additional configuration option in the form name=value"
+    help="Additional configuration option in the form name=value",
 )
 arg.config_file = arg(
     "-f",
@@ -52,21 +64,30 @@ arg.config_file = arg(
     metavar="KEY=VALUE",
     action="append",
     default=[],
-    help="Additional configuration option whose value is loaded from file in the form name=filename"
+    help="Additional configuration option whose value is loaded from file in the form name=filename",
 )
 arg.country_code = arg("--country-code", help="Billing country code")
 arg.email = arg("email", help="User email address")
-arg.force = arg("-f", "--force", help="Force action without interactive confirmation",
-                action="store_true", default=False)
+arg.force = arg(
+    "-f",
+    "--force",
+    help="Force action without interactive confirmation",
+    action="store_true",
+    default=False,
+)
 arg.index_name = arg("index_name", help="Index name")
 arg.json = arg("--json", help="Raw json output", action="store_true", default=False)
 arg.min_insync_replicas = arg(
-    "--min-insync-replicas", type=int,
+    "--min-insync-replicas",
+    type=int,
     help="Minimum required nodes In Sync Replicas (ISR) to produce to a partition (default: 1)",
 )
 arg.partitions = arg("--partitions", type=int, required=True, help="Number of partitions")
-arg.project = arg("--project", help="Project name to use, default %(default)r",
-                  default=os.environ.get("AIVEN_PROJECT"))
+arg.project = arg(
+    "--project",
+    help="Project name to use, default %(default)r",
+    default=os.environ.get("AIVEN_PROJECT"),
+)
 arg.replication = arg("--replication", type=int, required=True, help="Replication factor")
 arg.retention = arg("--retention", type=int, help="Retention period in hours (default: unlimited)")
 arg.retention_bytes = arg("--retention-bytes", type=int, help="Retention limit in bytes (default: unlimited)")
@@ -76,11 +97,22 @@ arg.team_name = arg("--team-name", help="Team name", required=True)
 arg.team_id = arg("--team-id", help="Team identifier", required=True)
 arg.timeout = arg("--timeout", type=int, help="Wait for up to N seconds (default: infinite)")
 arg.topic = arg("topic", help="Topic name")
-arg.user_config = arg("-c", dest="user_config", metavar="KEY=VALUE", action="append", default=[],
-                      help="Apply a configuration setting. See 'avn service types -v' for available values.")
+arg.user_config = arg(
+    "-c",
+    dest="user_config",
+    metavar="KEY=VALUE",
+    action="append",
+    default=[],
+    help="Apply a configuration setting. See 'avn service types -v' for available values.",
+)
 arg.user_id = arg("--user-id", help="User identifier", required=True)
-arg.user_option_remove = arg("--remove-option", dest="user_option_remove", action="append", default=[],
-                             help="Remove a configuration setting. See 'avn service types -v' for available settings.")
+arg.user_option_remove = arg(
+    "--remove-option",
+    dest="user_option_remove",
+    action="append",
+    default=[],
+    help="Remove a configuration setting. See 'avn service types -v' for available settings.",
+)
 arg.vat_id = arg("--vat-id", help="VAT ID of an EU VAT area business")
 arg.verbose = arg("-v", "--verbose", help="Verbose output", action="store_true", default=False)
 arg.connector_name = arg("connector", help="Connector name")
@@ -91,7 +123,7 @@ arg.compatibility = arg(
     "--compatibility",
     required=True,
     choices=["BACKWARD", "FORWARD", "FULL", "NONE"],
-    help="Choose a compatibility level for the subject"
+    help="Choose a compatibility level for the subject",
 )
 arg.schema = arg("--schema", required=True, help="Schema string quote escaped")
 

--- a/aiven/client/envdefault.py
+++ b/aiven/client/envdefault.py
@@ -2,7 +2,6 @@
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
-
 """
 Configurable parameters via environment variables
 """

--- a/aiven/client/pretty.py
+++ b/aiven/client/pretty.py
@@ -3,7 +3,6 @@
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
-
 """Pretty-print JSON objects and lists as tables"""
 import datetime
 import decimal
@@ -43,7 +42,7 @@ def format_item(key, value):
         # as the output without quotes we'll go with the original
         json_v = json.dumps(value)
         quoted_v = '"{}"'.format(value)
-        if json_v == quoted_v or json_v.replace("\\u00a3", "£").replace("\\u20ac", "€") == quoted_v:
+        if (json_v == quoted_v or json_v.replace("\\u00a3", "£").replace("\\u20ac", "€") == quoted_v):
             formatted = value
         else:
             formatted = json_v
@@ -56,7 +55,7 @@ def format_item(key, value):
         json_v = json.dumps(value, sort_keys=True, cls=CustomJsonEncoder)
         quoted_v = '"{}"'.format(value)
         if json_v == quoted_v:
-            formatted = '{}'.format(value)
+            formatted = "{}".format(value)
         else:
             formatted = json_v
 
@@ -128,13 +127,7 @@ def yield_table(result, drop_fields=None, table_layout=None, header=True):
                 yield "    {:{}} = {}".format(key, max_key_width, value)
 
 
-def print_table(
-        result,
-        drop_fields=None,
-        table_layout=None,
-        header=True,
-        file=None):  # pylint: disable=redefined-builtin
+def print_table(result, drop_fields=None, table_layout=None, header=True, file=None):  # pylint: disable=redefined-builtin
     """print a list of dicts in a nicer table format"""
-    for row in yield_table(result, drop_fields=drop_fields, table_layout=table_layout,
-                           header=header):
+    for row in yield_table(result, drop_fields=drop_fields, table_layout=table_layout, header=header):
         print(row, file=file or sys.stdout)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,5 @@ pylint
 pytest
 # Lock isort version since pylint fails with the 5.x series at the moment.
 isort<5.0
+# Lock yapf version for consistent formatting behavior.
+yapf==0.27.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ else:
     # default to latest version on unknown platforms
     REQUIRES = LATEST
 
-
 setup(
     author="Aiven",
     author_email="support@aiven.io",
@@ -44,14 +43,14 @@ setup(
     url="https://aiven.io/",
     version=version.get_project_version("aiven/client/version.py"),
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Libraries',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,18 +56,18 @@ def test_create_user_config():
                             },
                             "with.dot": {
                                 "type": "integer",
-                            }
-                        }
+                            },
+                        },
                     }
-                }
+                },
             },
             "foo": {
                 "type": ["integer", "null"],
             },
             "main": {
                 "type": "integer",
-            }
-        }
+            },
+        },
     }
     config = cli.create_user_config(schema)
     assert config == {

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -11,15 +11,26 @@ import pytest
 pytestmark = [pytest.mark.unittest, pytest.mark.all]
 
 
-@pytest.mark.parametrize("value,expected", [
-    (1, "1"),
-    ("a_string", "a_string"),
-    (datetime.datetime(year=2019, month=12, day=23), "2019-12-23T00:00:00"),
-    ([datetime.datetime(year=2019, month=12, day=23)], "2019-12-23T00:00:00"),
-    (["x", datetime.datetime(year=2019, month=12, day=23)], "x, 2019-12-23T00:00:00"),
-    (decimal.Decimal("64.23"), "64.23"),
-    ({"a": decimal.Decimal("12.34"), "b": datetime.datetime(year=2019, month=12, day=23)},
-     '{"a": "12.34", "b": "2019-12-23T00:00:00"}')
-])
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (1, "1"),
+        ("a_string", "a_string"),
+        (datetime.datetime(year=2019, month=12, day=23), "2019-12-23T00:00:00"),
+        ([datetime.datetime(year=2019, month=12, day=23)], "2019-12-23T00:00:00"),
+        (
+            ["x", datetime.datetime(year=2019, month=12, day=23)],
+            "x, 2019-12-23T00:00:00",
+        ),
+        (decimal.Decimal("64.23"), "64.23"),
+        (
+            {
+                "a": decimal.Decimal("12.34"),
+                "b": datetime.datetime(year=2019, month=12, day=23),
+            },
+            '{"a": "12.34", "b": "2019-12-23T00:00:00"}',
+        ),
+    ],
+)
 def test_format_item(value, expected):
     assert format_item(None, value) == expected

--- a/version.py
+++ b/version.py
@@ -17,9 +17,11 @@ def get_project_version(version_file):
         file_ver = None
 
     try:
-        proc = subprocess.Popen(["git", "describe", "--always"],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        proc = subprocess.Popen(
+            ["git", "describe", "--always"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
         stdout, _ = proc.communicate()
         if stdout:
             git_ver = stdout.splitlines()[0].strip().decode("utf-8")
@@ -30,12 +32,12 @@ def get_project_version(version_file):
         pass
 
     if not file_ver:
-        raise Exception("version not available from git or from file %r"
-                        % version_file)
+        raise Exception("version not available from git or from file %r" % version_file)
 
     return file_ver
 
 
 if __name__ == "__main__":
     import sys
+
     get_project_version(sys.argv[1])


### PR DESCRIPTION
aiven-client did not implement any code-formatting style other then enforcing isort.

As a result this is a "rip the bandaid off" PR which implements `yapf ==0.27.0` as the code-formatting style for this library and reformats all the existing code to match it.

pylint and flake8 are updated to ensure a consistent formatting experience. The sequence: `make reformat && make test` now represents commitable, passing PRs.