### PR TITLE
Add uniform support for data output format.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
       name: PyLint
       script:
         - pip install -r requirements.dev.txt
+        - pip install -e .
         - make pylint
 
     # MacOS we want to ensure system-python is working properly

--- a/aiven/client/pretty.py
+++ b/aiven/client/pretty.py
@@ -4,13 +4,16 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 """Pretty-print JSON objects and lists as tables"""
+# string type checking must work on python 2.x and 3.x
+from collections.abc import Mapping, Sequence
+
 import datetime
 import decimal
 import fnmatch
+import itertools
 import json
 import sys
 
-# string type checking must work on python 2.x and 3.x
 try:
     basestring
 except NameError:
@@ -29,23 +32,47 @@ class CustomJsonEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def format_item(key, value):
+def flatten_list(val, max_depth=-1, keys=None):
+    """Flatten a list out such that it can be represented as a table."""
+    if keys is None:
+        result = []
+        for subval in val:
+            result.append(flatten_list(subval, max_depth=max_depth, keys=()))
+        return result
+
+    rdict = {}
+    if max_depth == -1 or len(keys) != max_depth:
+        if isinstance(val, (Mapping, )):
+            for key, subval in val.items():
+                rdict.update(flatten_list(subval, max_depth=max_depth, keys=keys + (str(key), )))
+        elif isinstance(val, (Sequence, )) and not isinstance(val, (basestring, )):
+            rdict = {}
+            for idx, subval in enumerate(val):
+                rdict.update(flatten_list(subval, max_depth=max_depth, keys=keys + (str(idx), )))
+        else:
+            rdict = {".".join(keys if len(keys) > 0 else ("_raw", )): val}
+        return rdict
+    else:
+        # Plain type should be able to render itself
+        rdict = {".".join(keys if len(keys) > 0 else ("_raw", )): val}
+        return rdict
+
+
+def extract_fields(seq_of_maps):
+    """Return the full of list fields in a possibly printed sequence"""
+    seen_items = set()
+    fields = []
+    for item in seq_of_maps:
+        fields.extend([key for key in item.keys() if key not in seen_items])
+        seen_items.update(set(fields))
+    return tuple(fields)
+
+
+def format_item(value):
     if isinstance(value, list):
-        formatted = ", ".join(format_item(None, entry) for entry in value)
+        formatted = ", ".join(format_item(entry) for entry in value)
     elif isinstance(value, dict):
         formatted = json.dumps(value, sort_keys=True, cls=CustomJsonEncoder)
-    elif isinstance(value, basestring):
-        if key and key.endswith("_time") and value.endswith("Z") and "." in value:
-            # drop microseconds from timestamps
-            value = value.split(".", 1)[0] + "Z"
-        # json encode strings, but if the input string is exactly the same
-        # as the output without quotes we'll go with the original
-        json_v = json.dumps(value)
-        quoted_v = '"{}"'.format(value)
-        if (json_v == quoted_v or json_v.replace("\\u00a3", "£").replace("\\u20ac", "€") == quoted_v):
-            formatted = value
-        else:
-            formatted = json_v
     elif isinstance(value, datetime.datetime):
         formatted = value.isoformat()
     elif isinstance(value, datetime.timedelta):
@@ -62,69 +89,111 @@ def format_item(key, value):
     return formatted
 
 
+class PreparedTableData:  # pylint: disable=too-few-public-methods
+    """PreparedTableData represents prepared data for methods which render tables."""
+
+    def __init__(self, fields, table_rows, horizontal_fields, vertical_fields):
+        self.fields = fields
+        self.table_rows = table_rows
+        self.horizontal_fields = horizontal_fields
+        self.vertical_fields = vertical_fields
+
+
+def prepare_table(result, table_layout=None):
+    if result is None:
+        return PreparedTableData([], [], [], [])
+
+    if not isinstance(result, Sequence) or isinstance(result, basestring):
+        raise Exception("yield_table cannot render a non-sequence type argument - got: {}".format(type(result)))
+
+        # default table layout is one row per item with sorted field names
+    if table_layout is not None:
+        # Treat empty layout as a null layout since it leads to less confusing behavior.
+        if len(table_layout) == 0:
+            table_layout = None
+        else:
+            if not isinstance(table_layout[0], Sequence) or isinstance(table_layout[0], basestring):
+                table_layout = [table_layout]
+
+    table_rows = flatten_list(result)
+    fields = extract_fields(table_rows)
+
+    if table_layout is None:
+        table_layout = [tuple(sorted(fields))]
+
+    horizontal_fields = tuple(str(field_name) for field_name in table_layout[0])
+    vertical_fields = tuple(str(field_name) for field_name in table_layout[1:])
+
+    return PreparedTableData(fields, table_rows, horizontal_fields, vertical_fields)
+
+
+def yield_vertical_fields(formatted_row, vertical_fields):
+    """Yields the rendered vertical rows of a table"""
+    # And the rest of the fields, one per field
+    fields_to_print = []
+    for vertical_field in vertical_fields:
+        if vertical_field.endswith(".*"):
+            for key, value in sorted(formatted_row.items()):
+                if fnmatch.fnmatch(key, vertical_field):
+                    fields_to_print.append((key, value))
+        else:
+            value = formatted_row.get(vertical_field)
+            if value is not None:
+                fields_to_print.append((vertical_field, value))
+    if fields_to_print:
+        max_key_width = max(len(key) for key, _ in fields_to_print)
+        for key, value in fields_to_print:
+            yield "{:{}} = {}".format(key, max_key_width, value)
+
+
 def yield_table(result, drop_fields=None, table_layout=None, header=True):
     """format a list of dicts in a nicer table format yielding string rows"""
-    if not result:
-        return
 
-    if not isinstance(result[0], dict):
-        for item in result:
-            yield format_item(None, item)
-        return
+    prepared_data = prepare_table(result, table_layout)
 
     drop_fields = set(drop_fields or [])
 
-    def iter_values(key, value):
-        if not isinstance(value, dict):
-            yield key, value
-            return
-        for subkey, subvalue in value.items():
-            for kv in iter_values((key + "." if key else "") + subkey, subvalue):
-                yield kv
+    # format all fields and collect their widths (start at column_name in case it's bigger)
+    widths = {
+        column_name: len(column_name)
+        for column_name in set(prepared_data.fields).union(set(prepared_data.horizontal_fields))
+    }
+    formatted_rows = []
 
-    # format all fields and collect their widths
-    widths = {}
-    formatted_values = []
-    for item in result:
+    for item in prepared_data.table_rows:
         formatted_row = {}
-        formatted_values.append(formatted_row)
-        for key, value in item.items():
-            if key not in drop_fields:
-                for subkey, subvalue in iter_values(key, value):
-                    formatted_row[subkey] = format_item(subkey, subvalue)
-                    widths[subkey] = max(len(subkey), len(formatted_row[subkey]), widths.get(subkey, 1))
+        for column_name in item:
+            formatted_value = format_item(item[column_name])
+            if widths[column_name] < len(formatted_value):
+                widths[column_name] = len(formatted_value)
+            if column_name not in drop_fields:
+                formatted_row[column_name] = formatted_value
+        formatted_rows.append(formatted_row)
 
-    # default table layout is one row per item with sorted field names
-    if table_layout is None:
-        table_layout = sorted(widths)
-    if not isinstance(table_layout[0], (list, tuple)):
-        table_layout = [table_layout]
+    # The goal of this code is to render a table which can include named parameters as part
+    # of the cell output:
 
-    horizontal_fields = table_layout[0]
     if header:
-        yield "  ".join(f.upper().ljust(widths[f]) for f in horizontal_fields)
-        yield "  ".join("=" * widths[f] for f in horizontal_fields)
-    for row_num, formatted_row in enumerate(formatted_values):
+        yield "  ".join(f.upper().ljust(widths[f]) for f in prepared_data.horizontal_fields)
+        yield "  ".join("=" * widths[f] for f in prepared_data.horizontal_fields)
+    for row_num, formatted_row in enumerate(formatted_rows):
         # If we have multiple lines per entry yield an empty line between each entry
-        if len(table_layout) > 1 and row_num > 0:
+        if row_num > 0 and len(prepared_data.vertical_fields) > 0:
             yield ""
         # The main, horizontal, line
-        yield "  ".join(formatted_row.get(f, "").ljust(widths[f]) for f in horizontal_fields).strip()
-        # And the rest of the fields, one per field
-        fields_to_print = []
-        for vertical_field in table_layout[1:]:
-            if vertical_field.endswith(".*"):
-                for key, value in sorted(formatted_row.items()):
-                    if fnmatch.fnmatch(key, vertical_field):
-                        fields_to_print.append((key, value))
-            else:
-                value = formatted_row.get(vertical_field)
-                if value is not None:
-                    fields_to_print.append((vertical_field, value))
-        if fields_to_print:
-            max_key_width = max(len(key) for key, _ in fields_to_print)
-            for key, value in fields_to_print:
-                yield "    {:{}} = {}".format(key, max_key_width, value)
+        row = "  ".join(formatted_row.get(f, "").ljust(widths[f]) for f in prepared_data.horizontal_fields)
+        row_len = len(row)
+
+        # Render the vertical rows as the last column of each row.
+        for row, vertical_row in itertools.zip_longest([row],
+                                                       yield_vertical_fields(formatted_row, prepared_data.vertical_fields)):
+            if row is None:
+                row = " " * row_len
+            full_row = [row]
+            if vertical_row is not None:
+                full_row.append(vertical_row)
+
+            yield "  ".join(full_row)
 
 
 def print_table(result, drop_fields=None, table_layout=None, header=True, file=None):  # pylint: disable=redefined-builtin

--- a/setup.py
+++ b/setup.py
@@ -7,23 +7,22 @@ from setuptools import setup, find_packages
 import sys
 import version
 
-LATEST = [
-    "requests >= 2.9.1",
-    "certifi >= 2015.11.20.1",
-]
+LATEST = {
+    "requests": ">= 2.9.1",
+    "certifi": ">= 2015.11.20.1",
+    "ruamel.yaml": ">= 0.16.5",
+}
+
+REQUIRES = LATEST.copy()
+
+if (sys.version_info.major, sys.version_info.minor) <= (3, 4):
+    # Use an older version of ruamel.yaml for Python 3.4
+    REQUIRES["ruamel.yaml"] = "== 0.15.94"
 
 if sys.platform.startswith("linux"):
-    REQUIRES = [
-        # no bundled certifi as distro packages are expected to be patched to use system ca certs
-        "requests >= 2.2.1",  # minimum defined by Ubuntu Trusty (14.04LTS)
-    ]
-elif sys.platform == "darwin":
-    REQUIRES = LATEST
-elif sys.platform.startswith("win"):
-    REQUIRES = LATEST
-else:
-    # default to latest version on unknown platforms
-    REQUIRES = LATEST
+    REQUIRES["requests"] = ">= 2.2.1"  # minimum defined by Ubuntu Trusty (14.04LTS)
+    # No bundled certifi as distro packages are expected to be patched to use system ca certs
+    REQUIRES.pop("certifi")
 
 setup(
     author="Aiven",
@@ -33,7 +32,7 @@ setup(
             "avn = aiven.client.__main__:main",
         ],
     },
-    install_requires=REQUIRES,
+    install_requires=["{} {}".format(name, version) for name, version in REQUIRES.items()],
     license="Apache 2.0",
     name="aiven-client",
     packages=find_packages(exclude=["tests"]),

--- a/tests/test_argx.py
+++ b/tests/test_argx.py
@@ -1,0 +1,97 @@
+# Copyright 2015, Aiven, https://aiven.io/
+#
+# This file is under the Apache License, Version 2.0.
+# See the file `LICENSE` for details.
+
+from aiven.client.argx import CommandLineTool, OutputFormats
+
+import pytest
+
+pytestmark = [pytest.mark.unittest, pytest.mark.all]
+
+
+@pytest.mark.parametrize(
+    "value", [
+        1,
+        "a string",
+        [1, 2, 3, 4, 5],
+        [(1, 2), (3, 4), (5, 6)],
+        ["a", "bunch", "of", "strings"],
+        ["strings", "and", 1337, "numbers"],
+        {
+            "this": "is",
+            "a": "dict"
+        },
+        [
+            {
+                "nested": {
+                    "a": 1,
+                    "b": 2,
+                }
+            },
+            {
+                "nested": {
+                    "a": 3,
+                    "b": 5,
+                }
+            },
+        ],
+        [{
+            "consistent": "dictionary"
+        }, {
+            "consistent": "keys"
+        }],
+        [{
+            "consistent": "dictionary"
+        }, {
+            "inconsistent": "keys"
+        }],
+    ]
+)
+@pytest.mark.parametrize("fmt", list(OutputFormats))
+def test_print_response(request, value, fmt):
+    cli = CommandLineTool(request.node.name)
+    cli._output_format = fmt  # pylint: disable=protected-access
+    print("\n")
+    cli.print_response(value)
+
+
+@pytest.mark.parametrize(
+    "value", [
+        ({
+            "nested": {
+                "a": 1,
+                "b": 2,
+                "e": 3,
+                "f": 4,
+                "g": 5
+            },
+        }, {
+            "nested": {
+                "a": 6,
+                "b": 7,
+                "c": 8,
+                "d": 9,
+                "e": 10,
+                "f": 11,
+            }
+        }),
+    ]
+)
+@pytest.mark.parametrize(
+    "table_layout", [
+        [("nested.a", "nested.b"), "nested.c", "nested.d", "nested.e", "nested.f"],
+        [("nested.a", "nested.b")],
+        [],
+        [("something_else", "nested.b")],
+        [("nested.a", "nested.b"), "something_else"],
+    ]
+)
+@pytest.mark.parametrize(
+    "fmt", [OutputFormats.TABLE, OutputFormats.TABLE_NOHEADER, OutputFormats.CSV, OutputFormats.CSV_NOHEADER]
+)
+def test_print_response_with_vertical_fields(request, value, fmt, table_layout):
+    cli = CommandLineTool(request.node.name)
+    cli._output_format = fmt  # pylint: disable=protected-access
+    cli.print_response(value, table_layout=table_layout)
+    print("\n")

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -33,4 +33,4 @@ pytestmark = [pytest.mark.unittest, pytest.mark.all]
     ],
 )
 def test_format_item(value, expected):
-    assert format_item(None, value) == expected
+    assert format_item(value) == expected


### PR DESCRIPTION
Modifies argx to collect a uniform set of specifiers at launch for log level, output format and output stream. This is passed to all command-line utilities and affects output via the `print_response` function.

This centralizes output selection and enables all commands to emit output using any supported format. YAML via the `ruamel.yaml` library is added as a supported format as a part of this patch.

`print_response` is shimmed to allow this version of the library to be backwards compatible, pending removal of redundant parameters from other tools.

Cross-tested as backwards compatible (commands work, output looks sensible) with the existing dependent tooling.