### PR TITLE
Documentation for decorator arg

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -53,6 +53,23 @@ class UserError(Exception):
 
 
 def arg(*args, **kwargs):
+    """ Declares an argument of an CLI command.
+
+    This decorator accepts the same arguments as `argparse.Parser::add_argument`.
+
+    Methods marked with this decorator will be exposed as a CLI command, the
+    argument is made available through the instance attribute `self.args`.
+    `args` is an `argparse.Namespace` instance.
+
+    Example usage::
+
+        class CLI(CommandLineTool):
+
+            @arg("n", type=int)
+            def command(self):
+                print(self.args.n)
+    """
+
     def wrap(func):
         arg_list = getattr(func, ARG_LIST_PROP, None)
         if arg_list is None:

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -31,9 +31,7 @@ AUTHENTICATION_METHOD_COLUMNS = [
 PLUGINS = []
 
 try:
-    from aiven.admin import (
-        plugin as adminplugin,
-    )  # pylint: disable=import-error,no-name-in-module
+    from aiven.admin import plugin as adminplugin  # pylint: disable=import-error,no-name-in-module
 
     PLUGINS.append(adminplugin)
 except ImportError:
@@ -228,7 +226,7 @@ class AivenCLI(argx.CommandLineTool):
                 if prop_name.startswith("_"):
                     continue
                 prop = getattr(plugin, prop_name)
-                arg_list = getattr(prop, "_arg_list", None)
+                arg_list = getattr(prop, argx.ARG_LIST_PROP, None)
                 if arg_list is not None:
                     cmd = prop_name.replace("__", " ").replace("_", "-")
                     if patterns and not all((p.search(cmd) or p.search(prop.__doc__)) for p in patterns):


### PR DESCRIPTION
This adds a bit of documentation to `arg`, the intention is to make it a bit easier to understand it's usage.