### PR TITLE
Add cli and client command to list invites

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3260,6 +3260,19 @@ server_encryption_options:
             print(ex.response.text)
             raise argx.UserError("Project user listing for '{}' failed".format(project_name))
 
+    @arg.json
+    @arg.project
+    def project__invite_list(self):
+        """Project user list"""
+        project_name = self.get_project()
+        try:
+            user_list = self.client.list_invited_project_users(project=project_name)
+            layout = [["invited_user_email", "inviting_user_email", "member_type", "invite_time"]]
+            self.print_response(user_list, json=self.args.json, table_layout=layout)
+        except client.Error as ex:
+            print(ex.response.text)
+            raise argx.UserError("Project user listing for '{}' failed".format(project_name))
+
     @arg.email
     @arg("--real-name", help="User real name", required=True)
     def user__create(self):

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1286,6 +1286,9 @@ class AivenClient(AivenClientBase):
     def list_project_users(self, project):
         return self.verify(self.get, self.build_path("project", project, "users"), result_key="users")
 
+    def list_invited_project_users(self, project):
+        return self.verify(self.get, self.build_path("project", project, "users"), result_key="invitations")
+
     def create_user(self, email, password, real_name, *, tenant=None):
         request = {
             "email": email,


### PR DESCRIPTION
Displays invited users which aren't displayed in the list-user command.

```
$ avn project invite-list --project ovo-uat
```
```
INVITED_USER_EMAIL    INVITING_USER_EMAIL     MEMBER_TYPE  INVITE_TIME
===================== ======================  ===========  ====================
bob@example.com       admin@example.com       read_only    2020-10-16T12:17:47Z
alice@example.com     admin@example.com       read_only    2020-10-16T12:17:48Z
eve@example.com       admin@example.com       read_only    2020-10-16T12:17:46Z
```
