### PR TITLE
argx: Sort subcommands alphabetically

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -2,7 +2,6 @@
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
-
 from aiven.client import envdefault, pretty
 
 import aiven.client.client
@@ -163,6 +162,9 @@ class CommandLineTool:  # pylint: disable=old-style-class
 
         for arg_prop in getattr(func, ARG_LIST_PROP, []):
             parser.add_argument(*arg_prop[0], **arg_prop[1])
+
+        # Ensure the list of actions remains sorted as we append to to it.
+        self.subparsers._choices_actions.sort(key=lambda item: item.dest)  # pylint: disable=protected-access
 
     def add_args(self, parser):
         pass  # override in sub-class

--- a/tests/test_argx.py
+++ b/tests/test_argx.py
@@ -1,0 +1,62 @@
+# Copyright 2020, Aiven, https://aiven.io/
+#
+# This file is under the Apache License, Version 2.0.
+# See the file `LICENSE` for details.
+
+from aiven.client.argx import arg, CommandLineTool
+
+
+class TestCLI(CommandLineTool):
+    @arg()
+    def xxx(self):
+        """7"""
+
+    @arg()
+    def aaa(self):
+        """1"""
+
+    @arg()
+    def ccc(self):
+        """4"""
+
+
+class SubCLI(CommandLineTool):
+    @arg()
+    def yyy(self):
+        """8"""
+
+    @arg()
+    def bbb(self):
+        """2"""
+
+    @arg()
+    def ddd(self):
+        """5"""
+
+
+class SubCLI2(CommandLineTool):
+    @arg()
+    def yyz(self):
+        """9"""
+
+    @arg()
+    def bbc(self):
+        """3"""
+
+    @arg()
+    def dde(self):
+        """6"""
+
+
+def test_extended_commands_remain_alphabetically_ordered():
+    cli = TestCLI("testcli")
+    cli.extend_commands(cli)  # Force the CLI to have its full arg set at execution
+
+    sl2 = SubCLI2("subcli2")
+    sl = SubCLI("subcli")
+
+    cli.extend_commands(sl2)
+    cli.extend_commands(sl)
+
+    action_order = [item.dest for item in cli.subparsers._choices_actions]  # pylint: disable=protected-access
+    assert action_order == ["aaa", "bbb", "bbc", "ccc", "ddd", "dde", "xxx", "yyy", "yyz"]


### PR DESCRIPTION
When using argx to build multiple tools, the subcommands weren't being
kept sorted. This patch ensures that the ordering of subcommands is
always alphabetical as opposed to based on the order of loading (which
is not consistent).