### PR TITLE
cli: self describing name

### DIFF
--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -91,7 +91,7 @@ arg.project = arg(
 arg.replication = arg("--replication", type=int, required=True, help="Replication factor")
 arg.retention = arg("--retention", type=int, help="Retention period in hours (default: unlimited)")
 arg.retention_bytes = arg("--retention-bytes", type=int, help="Retention limit in bytes (default: unlimited)")
-arg.service_name = arg("name", help="Service name")
+arg.service_name = arg("service_name", help="Service name")
 arg.service_type = arg("-t", "--service-type", help="Type of service (see 'service list-types')")
 arg.team_name = arg("--team-name", help="Team name", required=True)
 arg.team_id = arg("--team-id", help="Team identifier", required=True)


### PR DESCRIPTION
`name` is quite broad and sometimes it is hard to tell what name is necessary from the context, examples:

```
avn service keypair get --key-filepath /tmp/keyfile --cert-filepath /tmp/certfile
usage: avn service keypair get [-h] [--project PROJECT] --key-filepath
                               KEY_FILEPATH --cert-filepath CERT_FILEPATH
                               name keypair
avn service keypair get: error: the following arguments are required: name, keypair
```
and
```
avn service ca get --target-filepath /tmp/test.ca
usage: avn service ca get [-h] [--project PROJECT] --target-filepath
                          TARGET_FILEPATH
                          name ca
avn service ca get: error: the following arguments are required: name, ca
```

Calling the argument `service_name` should make it slightly easier to guess what value should be used.