### PR TITLE
bugfix: revert service_name to name

### DIFF
--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -91,7 +91,7 @@ arg.project = arg(
 arg.replication = arg("--replication", type=int, required=True, help="Replication factor")
 arg.retention = arg("--retention", type=int, help="Retention period in hours (default: unlimited)")
 arg.retention_bytes = arg("--retention-bytes", type=int, help="Retention limit in bytes (default: unlimited)")
-arg.service_name = arg("service_name", help="Service name")
+arg.service_name = arg("name", help="Service name", metavar="service_name")
 arg.service_type = arg("-t", "--service-type", help="Type of service (see 'service list-types')")
 arg.ns_name = arg("ns_name", help="Namespace name")
 arg.ns_type = arg("--ns-type", help="Namespace type ('aggregated' or 'unaggregated')", required=True)


### PR DESCRIPTION
The name of the variable should be kept `name` to not break existing
code, instead only the user facing string should be changed.

PR https://github.com/aiven/aiven-client/pull/159 broke the cli because it also changed the name of the variable used in the namespace `AttributeError: 'Namespace' object has no attribute 'name'`. This maintains the name as `name` and only changes the text used for the help text. [Referece](https://docs.python.org/3/library/argparse.html#metavar)