### PR TITLE
cli: fix format for single item

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -239,6 +239,8 @@ class CommandLineTool:  # pylint: disable=old-style-class
             writer = csvlib.DictWriter(file, extrasaction="ignore", fieldnames=fields)
             if header:
                 writer.writeheader()
+            if single_item:
+                result = [result]
             for item in result:
                 writer.writerow(item)
         else:

--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -219,6 +219,8 @@ class CommandLineTool:  # pylint: disable=old-style-class
             file = sys.stdout
 
         if format is not None:
+            if single_item:
+                result = [result]
             for item in result:
                 print(format.format(**item), file=file)
         elif json:


### PR DESCRIPTION
Currently, `---format` fails for `service get` with the following Exception:

``TypeError: format() argument after ** must be a mapping, not str``

This change fixes `--format` for all calls to `print_response` when `single_item` is `True`

EDIT:
Added fix for csv output as well