### PR TITLE
cli: fix user creation regression

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1148,7 +1148,7 @@ class AivenCLI(argx.CommandLineTool):
         acl_params = {
             key: arg_vars[key].split()
             for key in {"redis_acl_keys", "redis_acl_commands", "redis_acl_categories"}
-            if key in arg_vars
+            if arg_vars[key]
         }
         if acl_params:
             extra_params = {"access_control": acl_params}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,10 @@ def test_service_types_v():
     AivenCLI().run(args=["service", "types", "-v"])
 
 
+def test_service_user_create():
+    AivenCLI().run(args=["service", "user-create", "service", "--username", "username"])
+
+
 def test_help():
     AivenCLI().run(args=["help"])
 


### PR DESCRIPTION
User creation throws an exception when Redis ACL options are not provided.
Also, added a simple test case for this.