### PR TITLE
Update project name finding for endpoints that were erroring

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1343,7 +1343,7 @@ ssl.truststore.type=JKS
     @arg.json
     def service__integration_endpoint_types_list(self):
         """List all available integration endpoint types for given project"""
-        endpoint_types = self.client.get_service_integration_endpoint_types(self.args.project)
+        endpoint_types = self.client.get_service_integration_endpoint_types(self.get_project())
         layout = ["title", "endpoint_type", "service_types"]
         self.print_response(endpoint_types, json=self.args.json, table_layout=layout)
 
@@ -1429,7 +1429,7 @@ ssl.truststore.type=JKS
     @arg.json
     def service__integration_types_list(self):
         """List all available integration types for given project"""
-        endpoint_types = self.client.get_service_integration_types(self.args.project)
+        endpoint_types = self.client.get_service_integration_types(self.get_project())
         layout = [
             "integration_type",
             "dest_description",


### PR DESCRIPTION
Make --project required for `avn service integration_types` and
`avn service integration_endpoint_types`. Fixes #153

(I'm not sure if there's a better way to extend the existing `@arg.project` definition, very happy to refactor if another approach is recommended).