### PR TITLE
Add python 3.9 to the build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
We moved the builds to GitHub Actions, but we didn't update to include the current version of Python, 3.9. This is now included.