### PR TITLE
gh_actions: only trigger in pull requests/tags and add filter for push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,12 @@
 name: Build Aiven Client
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '**'
+  pull_request:
 
 jobs:
 


### PR DESCRIPTION
Currently we trigger the workflow file for every push and pull request event. For example, every time we create a PR we run 2x, when we create a branch we run, etc.

Is this the goal? Or shoud we start using the following conditions?
- `push`: trigger only when we merge to master
- `tags`: every time we create a tag
- `pull request`: every time we create and update a pull request
