### PR TITLE
Don't start PyPI publish action unnecessarily

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,7 +1,10 @@
 # Based on https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 name: Publish to PyPI
-on: push
+on:
+  push:
+    tags:
+      - '**'
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Only start Publish to PyPI GitHub Action for tags to reduce unnecessary duplicating build workflows.