### PR TITLE
Add basic contributing and issue/PR template files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Welcome!
+
+Contributions to Karapaceh are very welcome. Please follow our guidelines:
+
+- It's recommended to open an issue to discuss a feature before putting in a lot of effort.
+
+- We use [GitHub Flow](https://guides.github.com/introduction/flow/), check that your main branch is up to date, and create a new branch for changes.
+
+- Commit messages should describe the changes, not the filenames. Win our admiration by following the [excellent advice from Chris Beams](https://chris.beams.io/posts/git-commit/) when composing commit messages.
+
+- Choose a meaningful title for your pull request.
+
+- The pull request description should focus on what changed and why.
+
+- Check that the tests pass (and add test coverage for your changes if appropriate).
+
+- Stay in touch with us if we have follow up questions or requests for further changes.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Welcome!
 
-Contributions to Karapaceh are very welcome. Please follow our guidelines:
+Contributions to aiven-client are very welcome. Please follow our guidelines:
 
 - It's recommended to open an issue to discuss a feature before putting in a lot of effort.
 

--- a/.github/ISSUE_TEMPLATE/01_question.md
+++ b/.github/ISSUE_TEMPLATE/01_question.md
@@ -1,0 +1,10 @@
+---
+name: ❓ Ask a question
+about: Got stuck or missing something from the docs? Ask away!
+---
+
+# What can we help you with?
+
+
+
+# Where would you expect to find this information?

--- a/.github/ISSUE_TEMPLATE/02_bug.md
+++ b/.github/ISSUE_TEMPLATE/02_bug.md
@@ -1,0 +1,17 @@
+---
+name: 🐜 Report a bug
+about: Spotted a problem? Let us know
+---
+
+# What happened?
+
+
+
+# What did you expect to happen?
+
+
+
+# What else do we need to know?
+
+Include your platform, version, and any other information that seems relevant.
+

--- a/.github/ISSUE_TEMPLATE/03_feature.md
+++ b/.github/ISSUE_TEMPLATE/03_feature.md
@@ -1,0 +1,16 @@
+---
+name: 💡 Feature suggestion
+about: What would make this even better?
+---
+
+# What is currently missing?
+
+
+
+# How could this be improved?
+
+
+
+# Is this a feature you would work on yourself?
+
+[ ] I plan to open a pull request for this feature

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+# About this change: What it does, why it matters
+
+(all contributors please complete this section, including maintainers)
+
+


### PR DESCRIPTION
Add some helper files to orientate and encourage new contributors to the project. Includes: 
- a contributing file, which prompts when someone opens a pull request for the first time
- a pull request template to remind everyone to explain what the change is and why we care
- a set of issue templates for bugs/features/questions to help get the right information for each type (blank issues are still enabled)