### PR TITLE
cli: accept token in avn login command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,12 @@ password you use on Aiven::
 
 The command will prompt you for your password.
 
+You can also use an access token generated in the Aiven Console::
+
+  $ avn user login <you@example.com> --token
+
+You will be prompted for your access token as above.
+
 .. _help-command:
 .. _basic-usage:
 


### PR DESCRIPTION
For users with platform authentication disabled the `avn login` command
cannot authenticate the aiven-client. This authentication method may
have been excluded by admins at the account level.

To authenticate the client the user could edit the JSON configuration
file to add an authentication token directly, but by accepting it also
in the `avn login` command we can make the functionality more easily
discoverable.

