### PR TITLE
Add custom datadog tags

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1530,11 +1530,14 @@ ssl.truststore.type=JKS
     @arg.project
     @arg("-d", "--endpoint-name", help="Integration endpoint name", required=True)
     @arg("-t", "--endpoint-type", help="Integration endpoint type", required=True)
+    @arg.user_config_json()
     @arg.user_config
     @arg.json
     def service__integration_endpoint_create(self):
         """Create a service integration endpoint"""
-        if self.args.user_config:
+        if self.args.user_config_json:
+            user_config = self.args.user_config_json
+        elif self.args.user_config:
             project = self.get_project()
             user_config_schema = self._get_endpoint_user_config_schema(
                 project=project, endpoint_type_name=self.args.endpoint_type
@@ -1553,10 +1556,13 @@ ssl.truststore.type=JKS
     @arg.project
     @arg("endpoint_id", help="Service integration endpoint ID")
     @arg.user_config
+    @arg.user_config_json()
     @arg.json
     def service__integration_endpoint_update(self):
         """Update a service integration endpoint"""
-        if self.args.user_config:
+        if self.args.user_config_json:
+            user_config = self.args.user_config_json
+        elif self.args.user_config:
             project = self.get_project()
             integration_endpoints = self.client.get_service_integration_endpoints(project=self.get_project())
             endpoint_type = None
@@ -1626,10 +1632,13 @@ ssl.truststore.type=JKS
     @arg("-S", "--source-endpoint-id", help="Source integration endpoint id")
     @arg("-D", "--dest-endpoint-id", help="Destination integration endpoint id")
     @arg.user_config
+    @arg.user_config_json()
     @arg.json
     def service__integration_create(self):
         """Create a service integration"""
-        if self.args.user_config:
+        if self.args.user_config_json:
+            user_config = self.args.user_config_json
+        elif self.args.user_config:
             project = self.get_project()
             user_config_schema = self._get_integration_user_config_schema(
                 project=project, integration_type_name=self.args.integration_type
@@ -1651,10 +1660,13 @@ ssl.truststore.type=JKS
     @arg.project
     @arg("integration_id", help="Service integration ID")
     @arg.user_config
+    @arg.user_config_json()
     @arg.json
     def service__integration_update(self):
         """Update a service integration"""
-        if self.args.user_config:
+        if self.args.user_config_json:
+            user_config = self.args.user_config_json
+        elif self.args.user_config:
             project = self.get_project()
             integration = self.client.get_service_integration(
                 project=project,
@@ -3707,6 +3719,7 @@ server_encryption_options:
         self.log.info("Aiven credentials written to: %s", aiven_credentials_filename)
 
     def _open_auth_token_file(self, mode="r"):
+        # pylint: disable=consider-using-with
         auth_token_file_path = self._get_auth_token_file_name()
         try:
             return open(auth_token_file_path, mode)

--- a/tests/test_cliarg.py
+++ b/tests/test_cliarg.py
@@ -1,0 +1,69 @@
+# Copyright 2015, Aiven, https://aiven.io/
+#
+# This file is under the Apache License, Version 2.0.
+# See the file `LICENSE` for details.
+
+# pylint: disable=no-member
+from aiven.client.argx import CommandLineTool
+from aiven.client.cliarg import arg
+
+
+def test_user_config_json_error_json():
+    """Test that @arg.user_config_json causes
+    CommandLineTool.run() to exit cleanly with return value 1
+    if JSON is incorrect
+    """
+
+    class T(CommandLineTool):
+        """Test class"""
+
+        @arg.user_config_json()
+        @arg()
+        def t(self):
+            """t"""
+
+    error_json_arg = ["t", "--user-config-json", "foo"]
+    test_class = T("avn")
+    ret = test_class.run(args=error_json_arg)
+    assert ret == 1
+
+
+def test_user_config_json_error_conflict():
+    """Test that @arg.user_config_json causes
+    CommandLineTool.run() to exit cleanly with return value 1
+    if both user_config (-c) and --user-config-json parameters
+    are given
+    """
+
+    class T(CommandLineTool):
+        """Test class"""
+
+        @arg.user_config
+        @arg.user_config_json()
+        @arg()
+        def t(self):
+            """t"""
+
+    error_conflict_arg = ["t", "-c", "userconfkey=val", "--user-config-json", '{"foo":"bar"}']
+    test_class = T("avn")
+    ret = test_class.run(args=error_conflict_arg)
+    assert ret == 1
+
+
+def test_user_config_json_success():
+    """Success scenario
+    """
+
+    class T(CommandLineTool):
+        """Test class"""
+
+        @arg.user_config_json()
+        @arg()
+        def t(self):
+            """t"""
+
+    valid_json_arg = ["t", "--user-config-json", '{"foo":"bar"}']
+    test_class = T("avn")
+    ret = test_class.run(args=valid_json_arg)
+    assert ret is None  # Should run() return 0 actually?
+    assert test_class.args.user_config_json == {"foo": "bar"}


### PR DESCRIPTION
Added "--user-config-json" parameter to support json in specifying
more complex user config for commands. The json document is checked
against schema in Aiven API, cli does only basic syntactic check.

The new parameter can be added with a decorator `user_config_json()`
found in aiven/client/cliarg.py:43

Currently the parameter is implemented for service integration related
commands.

Unit tests for the decorator are in tests/test_cliarg.py
