### PR TITLE
Add global --request-timeout arg

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -129,6 +129,12 @@ class AivenCLI(argx.CommandLineTool):
             help="Server base url default %(default)r",
             default=envdefault.AIVEN_WEB_URL or "https://api.aiven.io",
         )
+        parser.add_argument(
+            "--request-timeout",
+            type=int,
+            default=None,
+            help="Wait for up to N seconds for a response to a request (default: infinite)",
+        )
 
     def collect_user_config_options(self, obj_def, prefixes=None):
         opts = {}
@@ -3755,7 +3761,11 @@ server_encryption_options:
             raise
 
     def pre_run(self, func):
-        self.client = client.AivenClient(base_url=self.args.url, show_http=self.args.show_http)
+        self.client = client.AivenClient(
+            base_url=self.args.url,
+            show_http=self.args.show_http,
+            request_timeout=self.args.request_timeout,
+        )
         # Always set CA if we have anything set at the command line or in the env
         if self.args.auth_ca is not None:
             self.client.set_ca(self.args.auth_ca)

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2,6 +2,7 @@
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
+from .session import get_requests_session
 from urllib.parse import quote
 
 import json
@@ -32,17 +33,12 @@ UNDEFINED = object()
 class AivenClientBase:  # pylint: disable=old-style-class
     """Aiven Client with low-level HTTP operations"""
 
-    def __init__(self, base_url, show_http=False):
+    def __init__(self, base_url, show_http=False, request_timeout=None):
         self.log = logging.getLogger("AivenClient")
         self.auth_token = None
         self.base_url = base_url
         self.log.debug("using %r", self.base_url)
-        self.session = requests.Session()
-        self.session.verify = True
-        self.session.headers = {
-            "content-type": "application/json",
-            "user-agent": "aiven-client/" + __version__,
-        }
+        self.session = get_requests_session(timeout=request_timeout)
         self.http_log = logging.getLogger("aiven_http")
         self.init_http_logging(show_http)
         self.api_prefix = "/v1"

--- a/aiven/client/session.py
+++ b/aiven/client/session.py
@@ -1,0 +1,34 @@
+from requests import adapters, Session
+from requests.structures import CaseInsensitiveDict
+from typing import Optional
+
+try:
+    from .version import __version__  # pylint: disable=no-name-in-module
+except ImportError:
+    __version__ = "UNKNOWN"
+
+
+class AivenClientAdapter(adapters.HTTPAdapter):
+    def __init__(self, *args, timeout: Optional[int] = None, **kwargs):
+        self.timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        if not kwargs.get("timeout"):
+            kwargs["timeout"] = self.timeout
+        return super().send(*args, **kwargs)
+
+
+def get_requests_session(*, timeout: Optional[int] = None) -> Session:
+    adapter = AivenClientAdapter(timeout=timeout)
+
+    session = Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.verify = True
+    session.headers = CaseInsensitiveDict({
+        "content-type": "application/json",
+        "user-agent": "aiven-client/" + __version__,
+    })
+
+    return session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,37 @@
+# Copyright 2015, Aiven, https://aiven.io/
+#
+# This file is under the Apache License, Version 2.0.
+# See the file `LICENSE` for details.
+
+# pylint: disable=no-member
+from aiven.client.session import AivenClientAdapter, get_requests_session
+from requests import Session
+
+import pytest
+
+
+def test_valid_requests_session():
+    """Test that get_requests_session returns a valid Session that has the expected parameters set.
+    """
+
+    session = get_requests_session()
+
+    assert isinstance(session, Session)
+    assert "aiven-client" in session.headers["User-Agent"]
+
+    adapter = session.adapters["https://"]
+    assert isinstance(adapter, AivenClientAdapter)
+    assert hasattr(adapter, "timeout")
+    assert adapter.timeout is None
+
+
+@pytest.mark.parametrize("argument,value", [
+    ("timeout", 30),
+    ("timeout", 0),
+])
+def test_adapter_parameters_are_passed_along(argument, value):
+    session = get_requests_session(**{argument: value})
+    adapter = session.adapters["https://"]
+    assert isinstance(adapter, AivenClientAdapter)
+    assert hasattr(adapter, argument)
+    assert getattr(adapter, argument) == value


### PR DESCRIPTION
# About this change: What it does, why it matters
This allows the user to specify a maximum duration for a connection to be established and request responded to. This is helpful in automated processes where you want to limit the amount of time spent waiting, as it may indicate connectivity issues that is handled separately.