### PR TITLE
Improve assertion message for missing command docstring

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -133,7 +133,7 @@ class CommandLineTool:  # pylint: disable=old-style-class
 
     def add_cmd(self, func):
         """Add a parser for a single command method call"""
-        assert func.__doc__, func
+        assert func.__doc__, f"Missing docstring for {func.__qualname__}"
 
         # allow multi-level commands, separating each level with double underscores
         if "__" in func.__name__:


### PR DESCRIPTION
# About this change: What it does, why it matters

This allows contributors to see their mistake more quickly, when adding a new method that's missing a docstring :slightly_smiling_face: 

