### PR TITLE
jhonkola: add parameter to project creation

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3328,6 +3328,15 @@ ssl.truststore.type=JKS
         metavar="PROJECT",
         help="Copy project settings from an existing project",
     )
+    @arg(
+        "--use-source-project-billing-group",
+        action="store_true",
+        default=False,
+        help=(
+            "If copying from existing project, use the same billing group "
+            "used by source project instead of creating a new one"
+        )
+    )
     @arg.country_code
     @arg.billing_address
     @arg.billing_extra_text
@@ -3352,6 +3361,7 @@ ssl.truststore.type=JKS
                 vat_id=self.args.vat_id,
                 billing_emails=self.args.billing_email,
                 tech_emails=self.args.tech_email,
+                use_source_project_billing_group=self.args.use_source_project_billing_group,
             )
         except client.Error as ex:
             if not self.args.no_fail_if_exists or ex.response.status_code != 409:

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1371,6 +1371,7 @@ class AivenClient(AivenClientBase):
         vat_id=None,
         billing_emails=None,
         tech_emails=None,
+        use_source_project_billing_group=None,
     ):
         body = {
             "card_id": card_id,
@@ -1397,6 +1398,8 @@ class AivenClient(AivenClientBase):
             body["billing_emails"] = [{"email": email} for email in billing_emails]
         if tech_emails is not None:
             body["tech_emails"] = [{"email": email} for email in tech_emails]
+        if use_source_project_billing_group is not None:
+            body["use_source_project_billing_group"] = use_source_project_billing_group
 
         return self.verify(self.post, "/project", body=body, result_key="project")
 


### PR DESCRIPTION
Added parameter `--use-source-project-billing-group` to control
billing group creation when doing a copy from existing project.

When used, the new project will use the same billing group as
the source project.


