### PR TITLE
ci: use python 3.9 for linting

### DIFF
--- a/aiven/client/session.py
+++ b/aiven/client/session.py
@@ -13,7 +13,7 @@ class AivenClientAdapter(adapters.HTTPAdapter):
         self.timeout = timeout
         super().__init__(*args, **kwargs)
 
-    def send(self, *args, **kwargs):
+    def send(self, *args, **kwargs):  # pylint: disable=signature-differs
         if not kwargs.get("timeout"):
             kwargs["timeout"] = self.timeout
         return super().send(*args, **kwargs)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,6 @@
 flake8
-pylint
+# Lock pylint to the same version used in downstream build environments
+pylint==2.6.0
 pytest
 # Lock isort version since pylint fails with the 5.x series at the moment.
 isort<5.0


### PR DESCRIPTION
# About this change: What it does, why it matters

Downstream we were not able to build this because of a pylint error that CI didn't catch:
```
aiven/client/session.py:16:4: W0222: Signature differs from overridden 'send' method (signature-differs)
```

This ended up being because the downstream builds are using an older version of pylint (as provided by fedora 33 repos) that catches this issue, but the GHA CI was using an unpinned version of pylint (and therefore the newest version pip can find). I've pinned the version of pylint to our downstream use case to prevent this in the future, and added a disabler for the offending method.