### PR TITLE
Add migration check support and update PG versions for upgrade_check [BF-597]

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2084,9 +2084,9 @@ ssl.truststore.type=JKS
         default="upgrade_check",
     )
     @arg(
-        "--target_version",
+        "--target-version",
         help="Upgrade target version",
-        choices=["9.5", "9.6", "10", "11"],
+        choices=["10", "11", "12", "13"],
     )
     @arg("--format", help="Format string for output, e.g. '{name} {retention_hours}'")
     @arg.json

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2080,31 +2080,84 @@ ssl.truststore.type=JKS
     @arg(
         "--operation",
         help="Task operation",
-        choices=["upgrade_check"],
+        choices=["migration_check", "upgrade_check"],
         default="upgrade_check",
     )
     @arg(
         "--target-version",
         help="Upgrade target version",
         choices=["10", "11", "12", "13"],
+        required=False,
+    )
+    @arg(
+        "--source-service-uri",
+        help="Migration: source URI for migration",
+        required=False,
+    )
+    @arg(
+        "--ignore-dbs",
+        help="Migration: comma-separated list of databases to be ignored (MySQL only)",
+        required=False,
     )
     @arg("--format", help="Format string for output, e.g. '{name} {retention_hours}'")
     @arg.json
     def service__task_create(self):
         """Create a service task"""
+        if self.args.operation == "upgrade_check":
+            if not self.args.target_version:
+                raise argx.UserError("--target-version is required for this operation")
+            body = {
+                "task_type": self.args.operation,
+                "target_version": self.args.target_version,
+            }
+        elif self.args.operation == "migration_check":
+            if not self.args.source_service_uri:
+                raise argx.UserError("--source-service-uri is required for this operation")
+            body = {
+                "task_type": self.args.operation,
+                "migration_check": {
+                    "source_service_uri": self.args.source_service_uri
+                }
+            }
+            if self.args.ignore_dbs:
+                body["migration_check"]["ignore_dbs"] = self.args.ignore_dbs
+        else:
+            raise NotImplementedError(f"Operation {self.args.operation} is not implemented")
+
         response = self.client.create_service_task(
             project=self.get_project(),
             service=self.args.service_name,
-            operation=self.args.operation,
-            target_version=self.args.target_version,
+            body=body,
         )
         self.print_response(
             [response["task"]],
             format=self.args.format,
             json=self.args.json,
-            table_layout=["task_type", "success"],
+            table_layout=["task_type", "success", "task_id"],
         )
         print(response["task"]["result"])
+
+    @arg.project
+    @arg.service_name
+    @arg(
+        "--task-id",
+        help="Task id to check the status",
+    )
+    @arg("--format", help="Format string for output")
+    @arg.json
+    def service__task_get(self):
+        """Create a service task"""
+        response = self.client.get_service_task(
+            project=self.get_project(),
+            service=self.args.service_name,
+            task_id=self.args.task_id,
+        )
+        self.print_response(
+            [response],
+            format=self.args.format,
+            json=self.args.json,
+            table_layout=["task_type", "success", "task_id", "result"],
+        )
 
     @arg.project
     @arg.service_name

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -388,14 +388,11 @@ class AivenClient(AivenClientBase):
             self.build_path("project", project, "integration", integration_id),
         )
 
-    def create_service_task(self, project, service, operation, target_version):
+    def create_service_task(self, project, service, body):
         return self.verify(
             self.post,
             self.build_path("project", project, "service", service, "task"),
-            body={
-                "task_type": operation,
-                "target_version": target_version,
-            },
+            body=body,
         )
 
     def get_service_task(self, project, service, task_id):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@
 # pylint: disable=no-member
 from aiven.client.cli import AivenCLI
 from collections import namedtuple
+from unittest import mock
 
 import pytest
 
@@ -107,3 +108,69 @@ def test_create_user_config():
         "foo": None,
         "main": 3,
     }
+
+
+@pytest.fixture(name="authenticated_cli")
+def fixture_authenticated_cli():
+    def patched_get_auth_token():
+        return "token"
+
+    cli = AivenCLI()
+    cli._get_auth_token = patched_get_auth_token  # pylint: disable=protected-access
+    return cli
+
+
+def test_service_task_create_migration_check(authenticated_cli):
+    task_create_response = {
+        "message": "created",
+        "task": {
+            "create_time": "2021-08-13T08:00:45Z",
+            "result": "",
+            "success": None,
+            "task_id": "79803598-d09a-44bf-ae2b-34aad942f4e8",
+            "task_type": "mysql_migration_check"
+        }
+    }
+
+    with mock.patch("aiven.client.client.AivenClient") as cli_client_mock:
+        cli_client_mock.return_value.create_service_task.return_value = task_create_response
+        authenticated_cli.run(
+            args=[
+                "service", "task-create", "--operation", "migration_check", "--project", "test", "--source-service-uri",
+                "mysql://root:password@source-mysql-server:3306/", "--ignore-dbs", "db1", "target-mysql-service-1"
+            ]
+        )
+        cli_client_mock.return_value.create_service_task.assert_called_with(
+            project='test',
+            service='target-mysql-service-1',
+            body={
+                'task_type': 'migration_check',
+                'migration_check': {
+                    'source_service_uri': 'mysql://root:password@source-mysql-server:3306/',
+                    'ignore_dbs': 'db1'
+                }
+            }
+        )
+
+
+def test_service_task_get_migration_check(authenticated_cli):
+    task_get_response = {
+        "create_time": "2021-08-13T07:10:35Z",
+        "ignore_dbs": "defaultdb",
+        "result": "aiven_mysql_migrate.exceptions.NothingToMigrateException: No databases to migrate",
+        "success": False,
+        "task_id": "f25eac03-25f7-4de2-be6a-eb476fec1730",
+        "task_type": "mysql_migration_check"
+    }
+
+    with mock.patch("aiven.client.client.AivenClient") as cli_client_mock:
+        cli_client_mock.return_value.get_service_task.return_value = task_get_response
+        authenticated_cli.run(
+            args=[
+                "service", "task-get", "--task-id", "f25eac03-25f7-4de2-be6a-eb476fec1730", "--project", "test",
+                "target-mysql-service-1"
+            ]
+        )
+        cli_client_mock.return_value.get_service_task.assert_called_with(
+            project='test', service='target-mysql-service-1', task_id='f25eac03-25f7-4de2-be6a-eb476fec1730'
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,8 @@
 # See the file `LICENSE` for details.
 
 # pylint: disable=no-member
-from aiven.client.cli import AivenCLI
+from aiven.client import AivenClient
+from aiven.client.cli import AivenCLI, ClientFactory
 from collections import namedtuple
 from unittest import mock
 
@@ -110,18 +111,19 @@ def test_create_user_config():
     }
 
 
-@pytest.fixture(name="authenticated_cli")
-def fixture_authenticated_cli():
-    def patched_get_auth_token():
-        return "token"
+def patched_get_auth_token() -> str:
+    return "token"
 
-    cli = AivenCLI()
+
+def build_aiven_cli(client: AivenClient) -> AivenCLI:
+    cli = AivenCLI(client_factory=mock.Mock(spec_set=ClientFactory, return_value=client))
     cli._get_auth_token = patched_get_auth_token  # pylint: disable=protected-access
     return cli
 
 
-def test_service_task_create_migration_check(authenticated_cli):
-    task_create_response = {
+def test_service_task_create_migration_check():
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.create_service_task.return_value = {
         "message": "created",
         "task": {
             "create_time": "2021-08-13T08:00:45Z",
@@ -132,29 +134,28 @@ def test_service_task_create_migration_check(authenticated_cli):
         }
     }
 
-    with mock.patch("aiven.client.client.AivenClient") as cli_client_mock:
-        cli_client_mock.return_value.create_service_task.return_value = task_create_response
-        authenticated_cli.run(
-            args=[
-                "service", "task-create", "--operation", "migration_check", "--project", "test", "--source-service-uri",
-                "mysql://root:password@source-mysql-server:3306/", "--ignore-dbs", "db1", "target-mysql-service-1"
-            ]
-        )
-        cli_client_mock.return_value.create_service_task.assert_called_with(
-            project='test',
-            service='target-mysql-service-1',
-            body={
-                'task_type': 'migration_check',
-                'migration_check': {
-                    'source_service_uri': 'mysql://root:password@source-mysql-server:3306/',
-                    'ignore_dbs': 'db1'
-                }
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "service", "task-create", "--operation", "migration_check", "--project", "test", "--source-service-uri",
+            "mysql://root:password@source-mysql-server:3306/", "--ignore-dbs", "db1", "target-mysql-service-1"
+        ]
+    )
+    aiven_client.create_service_task.assert_called_with(
+        project='test',
+        service='target-mysql-service-1',
+        body={
+            'task_type': 'migration_check',
+            'migration_check': {
+                'source_service_uri': 'mysql://root:password@source-mysql-server:3306/',
+                'ignore_dbs': 'db1'
             }
-        )
+        }
+    )
 
 
-def test_service_task_get_migration_check(authenticated_cli):
-    task_get_response = {
+def test_service_task_get_migration_check():
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.get_service_task.return_value = {
         "create_time": "2021-08-13T07:10:35Z",
         "ignore_dbs": "defaultdb",
         "result": "aiven_mysql_migrate.exceptions.NothingToMigrateException: No databases to migrate",
@@ -163,14 +164,12 @@ def test_service_task_get_migration_check(authenticated_cli):
         "task_type": "mysql_migration_check"
     }
 
-    with mock.patch("aiven.client.client.AivenClient") as cli_client_mock:
-        cli_client_mock.return_value.get_service_task.return_value = task_get_response
-        authenticated_cli.run(
-            args=[
-                "service", "task-get", "--task-id", "f25eac03-25f7-4de2-be6a-eb476fec1730", "--project", "test",
-                "target-mysql-service-1"
-            ]
-        )
-        cli_client_mock.return_value.get_service_task.assert_called_with(
-            project='test', service='target-mysql-service-1', task_id='f25eac03-25f7-4de2-be6a-eb476fec1730'
-        )
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "service", "task-get", "--task-id", "f25eac03-25f7-4de2-be6a-eb476fec1730", "--project", "test",
+            "target-mysql-service-1"
+        ]
+    )
+    aiven_client.get_service_task.assert_called_with(
+        project='test', service='target-mysql-service-1', task_id='f25eac03-25f7-4de2-be6a-eb476fec1730'
+    )


### PR DESCRIPTION
* Added migration_check support to `service task-create` command
* Added command to check the status of a task - `service task-get`
* Updated list of supported PG versions for upgrade check (renamed target version parameter to match the style)

