### PR TITLE
Fix hyperlink syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -413,7 +413,7 @@ For more information (including completions usage in other shells) see https://k
 Auth Helpers
 ------------
 
-When you spin up a new service, you'll want to connect to it. The ``--json`` option combined with the [jq](https://stedolan.github.io/jq/) utility is a good way to grab the fields you need for your specific service. Try this to get the connection string::
+When you spin up a new service, you'll want to connect to it. The ``--json`` option combined with the `jq <https://stedolan.github.io/jq/>`_ utility is a good way to grab the fields you need for your specific service. Try this to get the connection string::
 
   $ avn service get --json <service> | jq ".service_uri"
 
@@ -421,7 +421,7 @@ Each project has its own CA cert, and other services (notably Kafka) use mutualT
 
   $ avn service user-creds-download --username avnadmin <service>
 
-For working with [kafkacat](https://github.com/edenhill/kafkacat) (see also our [help article](https://help.aiven.io/en/articles/2607674-using-kafkacat) ) or the command-line tools that ship with Kafka itself, a keystore and trustore are needed. By specifying which user's creds to use, and a secret, you can generate these via ``avn`` too::
+For working with `kafkacat <https://github.com/edenhill/kafkacat>`_ (see also our `help article <https://help.aiven.io/en/articles/2607674-using-kafkacat>`_ ) or the command-line tools that ship with Kafka itself, a keystore and trustore are needed. By specifying which user's creds to use, and a secret, you can generate these via ``avn`` too::
 
   $ avn service user-kafka-java-creds --username avnadmin -p t0pS3cr3t <service>
 


### PR DESCRIPTION
# Fix hyperlink

There are a few cases in the README file that hyperlink was written using the markdown syntax 

