### PR TITLE
cliarg: fix false parameter conflict bug

### DIFF
--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -11,6 +11,9 @@ import os
 
 
 def get_json_config(path_or_string):
+    # If parameter is empty, return an empty dict
+    if not path_or_string:
+        return {}
     if path_or_string.startswith("@"):
         filepath = path_or_string[1:]
         with open(filepath, "r") as config_file:
@@ -46,7 +49,7 @@ def user_config_json():
     def wrapper(fun):
         arg(
             "--user-config-json",
-            default="{}",
+            default=None,
             dest="user_config_json",
             help="JSON string or path (preceded by '@') to a JSON configuration file",
         )(fun)

--- a/tests/test_cliarg.py
+++ b/tests/test_cliarg.py
@@ -67,3 +67,23 @@ def test_user_config_json_success():
     ret = test_class.run(args=valid_json_arg)
     assert ret is None  # Should run() return 0 actually?
     assert test_class.args.user_config_json == {"foo": "bar"}
+
+
+def test_user_config_success():
+    """Test that user config parameter -c works and not cause conflict with
+    --user_config_json
+    """
+
+    class T(CommandLineTool):
+        """Test class"""
+
+        @arg.user_config
+        @arg.user_config_json()
+        @arg()
+        def t(self):
+            """t"""
+
+    user_config_arg = ["t", "-c", "userconfkey=val"]
+    test_class = T("avn")
+    ret = test_class.run(args=user_config_arg)
+    assert ret is None


### PR DESCRIPTION
Fix bug in `--user-config-json` parameter validation that caused an error
when `-c` parameter was used even if `--user-config-json` was not.





