### PR TITLE
Connection information commands for kafkacat and psql

### DIFF
--- a/aiven/client/connection_info/__init__.py
+++ b/aiven/client/connection_info/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/

--- a/aiven/client/connection_info/_utils.py
+++ b/aiven/client/connection_info/_utils.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from .common import ConnectionInfoError
+from typing import Mapping, Optional
+
+import ipaddress
+import urllib.parse
+
+
+def find_component(items, **filters):
+    for item in items:
+        if all(key in item and item[key] == value for key, value in filters.items()):
+            return item
+    msg_filters = ", ".join(f"{field}={value}" for field, value in filters.items())
+    raise ConnectionInfoError(f"Could not find connection information with filters {msg_filters}")
+
+
+def find_user(service, username):
+    for user in service["users"]:
+        if user["username"] == username:
+            return user
+    raise ConnectionInfoError(f"Could not find connection information for username {username}")
+
+
+def format_uri(
+    *,
+    scheme: str,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    netloc: Optional[str] = None,
+    path: str = "",
+    query: Optional[Mapping[str, str]] = None,
+    fragment: str = "",
+) -> str:
+    if netloc is None:
+        bits = []
+        if username is not None:
+            bits.append(urllib.parse.quote(username))
+        if password is not None:
+            bits.append(":")
+            bits.append(urllib.parse.quote(password))
+        if username is not None or password is not None:
+            bits.append("@")
+        if host is not None:
+            try:
+                ip = ipaddress.ip_address(host)
+            except ValueError:
+                # host not parseable as an IP address -> probably DNS name
+                pass
+            else:
+                if ip.version == 4:
+                    host = f"{ip}"
+                elif ip.version == 6:
+                    host = f"[{ip}]"
+                else:
+                    raise NotImplementedError(ip.version)
+            bits.append(host)
+            if port is not None and port != {"http": 80, "https": 443}.get(scheme.lower()):
+                bits.append(f":{port}")
+        netloc = "".join(bits)
+    return urllib.parse.urlunsplit((scheme, netloc, path, urllib.parse.urlencode(query), fragment))

--- a/aiven/client/connection_info/common.py
+++ b/aiven/client/connection_info/common.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from aiven.client.argx import UserError
+from enum import Enum
+
+import os
+
+
+class ConnectionInfoError(UserError):
+    def __init__(self, message):
+        super().__init__()
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+class Store(Enum):
+    overwrite = object()
+    write = object()
+    skip = object()
+
+    def handle(self, getter, path):
+        if self is Store.overwrite:
+            write = True
+        elif self is Store.write:
+            write = not os.path.exists(path)
+        elif self is Store.skip:
+            write = False
+        else:
+            raise NotImplementedError
+
+        if write:
+            value = getter()
+            with open(path, "w", encoding="utf-8") as fob:
+                fob.write(value)

--- a/aiven/client/connection_info/kafka.py
+++ b/aiven/client/connection_info/kafka.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from ._utils import find_component, find_user
+from .common import ConnectionInfoError, Store
+
+
+class KafkaConnectionInfo:  # pylint: disable=too-few-public-methods
+    def __init__(
+        self,
+        host,
+        port,
+    ):
+        self.host = host
+        self.port = port
+
+    def _kafkacat(self, protocol, ca_path, extra, store: Store, get_project_ca):
+        store.handle(get_project_ca, ca_path)
+        address = f"{self.host}:{self.port}"
+        return ["kafkacat", "-b", address, "-X", f"security.protocol={protocol}", "-X", f"ssl.ca.location={ca_path}", *extra]
+
+
+class KafkaCertificateConnectionInfo(KafkaConnectionInfo):
+    def __init__(self, host, port, client_cert, client_key):
+        super().__init__(host, port)
+        self.client_cert = client_cert
+        self.client_key = client_key
+
+    def kafkacat(self, store, get_project_ca, ca_path, client_key_path, client_cert_path):
+        store.handle(lambda: self.client_cert, client_cert_path)
+        store.handle(lambda: self.client_key, client_key_path)
+
+        extra = [
+            "-X",
+            f"ssl.key.location={client_key_path}",
+            "-X",
+            f"ssl.certificate.location={client_cert_path}",
+        ]
+        return self._kafkacat("SSL", ca_path, extra, store, get_project_ca)
+
+    @classmethod
+    def from_service(
+        cls,
+        service,
+        *,
+        route,
+        username,
+    ):
+        if service["service_type"] != "kafka":
+            raise ConnectionInfoError(
+                "Cannot format kafka connection info for service type {service_type}".format_map(service)
+            )
+
+        info = find_component(service["components"], route=route, kafka_authentication_method="certificate")
+        user = find_user(service, username)
+        if "access_cert" not in user:
+            raise ConnectionInfoError(f"Could not find client certificate for username {username}")
+        if "access_key" not in user:
+            raise ConnectionInfoError(f"Could not find client key for username {username}")
+
+        client_cert = user["access_cert"]
+        client_key = user["access_key"]
+        return cls(host=info["host"], port=info["port"], client_cert=client_cert, client_key=client_key)
+
+
+class KafkaSASLConnectionInfo(KafkaConnectionInfo):
+    def __init__(self, host, port, username, password):
+        super().__init__(host, port)
+        self.username = username
+        self.password = password
+
+    @classmethod
+    def from_service(
+        cls,
+        service,
+        *,
+        route,
+        username,
+    ):
+        if service["service_type"] != "kafka":
+            raise ConnectionInfoError(
+                "Cannot format kafka connection info for service type {service_type}".format_map(service)
+            )
+
+        info = find_component(service["components"], route=route, kafka_authentication_method="sasl")
+        user = find_user(service, username)
+        if "password" not in user:
+            raise ConnectionInfoError(f"Could not find password for username {username}")
+        return cls(host=info["host"], port=info["port"], username=username, password=user["password"])
+
+    def kafkacat(self, store, get_project_ca, ca_path):
+        extra = [
+            "-X",
+            "sasl.mechanisms=SCRAM-SHA-256",
+            "-X",
+            f"sasl.username={self.username}",
+            "-X",
+            f"sasl.password={self.password}",
+        ]
+        return self._kafkacat("SASL_SSL", ca_path, extra, store, get_project_ca)

--- a/aiven/client/connection_info/pg.py
+++ b/aiven/client/connection_info/pg.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 Aiven, Helsinki, Finland. https://aiven.io/
+from ._utils import find_component, find_user, format_uri
+from .common import ConnectionInfoError
+
+
+class PGConnectionInfo:
+    def __init__(self, host, port, username, dbname, password, sslmode):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.dbname = dbname
+        self.password = password
+        self.sslmode = sslmode
+
+    @classmethod
+    def from_service(cls, service, *, route, usage, username, dbname, sslmode):
+        if service["service_type"] != "pg":
+            raise ConnectionInfoError("Cannot format pg connection info for service type {service_type}".format_map(service))
+
+        info = find_component(service["components"], route=route, usage=usage)
+        host = info["host"]
+        port = info["port"]
+        user = find_user(service, username)
+        password = user.get("password")
+        if password is None:
+            raise ConnectionInfoError(f"Could not find password for username {username}")
+        return cls(host=host, port=port, username=username, dbname=dbname, password=password, sslmode=sslmode)
+
+    def params(self):
+        return {
+            "host": self.host,
+            "port": self.port,
+            "user": self.username,
+            "dbname": self.dbname,
+            "password": self.password,
+            "sslmode": self.sslmode,
+        }
+
+    def uri(self):
+        return format_uri(
+            scheme="postgres",
+            username=self.username,
+            password=self.password,
+            host=self.host,
+            port=self.port,
+            path=f"/{self.dbname}",
+            query={"sslmode": self.sslmode},
+        )
+
+    def connection_string(self):
+        return f"host='{self.host}' port='{self.port}' user={self.username} dbname='{self.dbname}'"
+
+    def psql(self):
+        return ["psql", self.uri()]

--- a/aiven/client/pretty.py
+++ b/aiven/client/pretty.py
@@ -32,7 +32,7 @@ class CustomJsonEncoder(json.JSONEncoder):
                 ipaddress.IPv4Interface, ipaddress.IPv6Interface
             )
         ):
-            return str(o)
+            return o.compressed
 
         return json.JSONEncoder.default(self, o)
 


### PR DESCRIPTION
Examples:
```
# avn service connection-info pg uri mypg  --route privatelink --replica
postgres://avnadmin:lfkjJfjQ6vQIG7Xr@privatelink-mypg.aiven.domain:21089/defaultdb?sslmode=require
# avn service connection-info kafkacat -a sasl --username mwf mykafka
kafkacat -b mykafka.aiven.domain:21100 -X security.protocol=SASL_SSL -X ssl.ca.location=ca.pem -X sasl.mechanisms=SCRAM-SHA-256 -X sasl.username=mwf -X sasl.password=eTKOcEM8ulGG4nCa
```
