### PR TITLE
cli: add support for tagging projects and services

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4188,6 +4188,59 @@ server_encryption_options:
             print(ex.response.text)
             raise argx.UserError("Project user listing for '{}' failed".format(project_name))
 
+    def _print_tags(self, tags):
+        layout = [["key", "value"]]
+        self.print_response(
+            [{
+                "key": key,
+                "value": value
+            } for key, value in tags["tags"].items()],
+            json=self.args.json,
+            table_layout=layout,
+        )
+
+    @staticmethod
+    def _parse_tag_arg(tag):
+        if "=" not in tag:
+            raise argx.UserError(f"Invalid tag key-value pair '{tag}', expected '<KEY>=<VALUE>'")
+        key, value = tag.split("=", maxsplit=1)
+        return key, value
+
+    def _tag_update_body_from_args(self):
+        tag_updates = {key: None for key in self.args.remove_tag}
+        tag_updates.update(dict(self._parse_tag_arg(tag) for tag in self.args.add_tag))
+        return tag_updates
+
+    def _tag_replace_body_from_args(self):
+        return dict(self._parse_tag_arg(tag) for tag in self.args.tag)
+
+    @arg.json
+    @arg.project
+    def project__tags__list(self):
+        """List project tags"""
+        project_name = self.get_project()
+        tags = self.client.list_project_tags(project=project_name)
+        self._print_tags(tags)
+
+    @arg.json
+    @arg.project
+    @arg("--add-tag", help="Add a new tag (key=value)", action="append", default=[])
+    @arg("--remove-tag", help="Remove the named tag", action="append", default=[])
+    def project__tags__update(self):
+        """Add or remove project tags"""
+        project_name = self.get_project()
+        response = self.client.update_project_tags(project=project_name, tag_updates=self._tag_update_body_from_args())
+        print(response["message"])
+
+    @arg.json
+    @arg.project
+    @arg("--tag", help="Tag for project (key=value)", action="append", default=[])
+    def project__tags__replace(self):
+        """Replace project tags, deleting any old ones first"""
+        project_name = self.get_project()
+        response = self.client.replace_project_tags(project=project_name, tags=self._tag_replace_body_from_args())
+        print(response["message"])
+
     @arg.email
     @arg("--real-name", help="User real name", required=True)
     def user__create(self):
@@ -4634,6 +4687,41 @@ server_encryption_options:
             "end_of_life_help_article_url",
         ]
         self.print_response(service_versions, table_layout=layout, json=self.args.json)
+
+    @arg.json
+    @arg.project
+    @arg.service_name
+    def service__tags__list(self):
+        """List service tags"""
+        tags = self.client.list_service_tags(project=self.get_project(), service=self.args.service_name)
+        self._print_tags(tags)
+
+    @arg.json
+    @arg.project
+    @arg.service_name
+    @arg("--add-tag", help="Add a new tag (key=value)", action="append", default=[])
+    @arg("--remove-tag", help="Remove the named tag", action="append", default=[])
+    def service__tags__update(self):
+        """Add or remove service tags"""
+        response = self.client.update_service_tags(
+            project=self.get_project(),
+            service=self.args.service_name,
+            tag_updates=self._tag_update_body_from_args(),
+        )
+        print(response["message"])
+
+    @arg.json
+    @arg.project
+    @arg.service_name
+    @arg("--tag", help="Tag for service (key=value)", action="append", default=[])
+    def service__tags__replace(self):
+        """Replace service tags, deleting any old ones first"""
+        response = self.client.replace_service_tags(
+            project=self.get_project(),
+            service=self.args.service_name,
+            tags=self._tag_replace_body_from_args(),
+        )
+        print(response["message"])
 
 
 if __name__ == "__main__":

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -105,6 +105,10 @@ class AivenClientBase:  # pylint: disable=old-style-class
         """HTTP GET"""
         return self._execute(self.session.get, "GET", path, body=None, params=params)
 
+    def patch(self, path="", body=None, params=None):
+        """HTTP PATCH"""
+        return self._execute(self.session.patch, "PATCH", path, body, params)
+
     def post(self, path="", body=None, params=None):
         """HTTP POST"""
         return self._execute(self.session.post, "POST", path, body, params)
@@ -1143,6 +1147,32 @@ class AivenClient(AivenClientBase):
             body["delete"] = delete
         return self.verify(self.put, path, body=body)
 
+    def list_project_tags(self, project):
+        path = self.build_path(
+            "project",
+            project,
+            "tags",
+        )
+        return self.verify(self.get, path)
+
+    def update_project_tags(self, project, tag_updates):
+        path = self.build_path(
+            "project",
+            project,
+            "tags",
+        )
+        body = {"tags": tag_updates}
+        return self.verify(self.patch, path, body=body)
+
+    def replace_project_tags(self, project, tags):
+        path = self.build_path(
+            "project",
+            project,
+            "tags",
+        )
+        body = {"tags": tags}
+        return self.verify(self.put, path, body=body)
+
     def create_service(
         self,
         project,
@@ -1344,6 +1374,38 @@ class AivenClient(AivenClientBase):
     def reset_service_query_stats(self, project, service):
         path = self.build_path("project", project, "service", service, "query", "stats", "reset")
         return self.verify(self.put, path, result_key="queries")
+
+    def list_service_tags(self, project, service):
+        path = self.build_path(
+            "project",
+            project,
+            "service",
+            service,
+            "tags",
+        )
+        return self.verify(self.get, path)
+
+    def update_service_tags(self, project, service, tag_updates):
+        path = self.build_path(
+            "project",
+            project,
+            "service",
+            service,
+            "tags",
+        )
+        body = {"tags": tag_updates}
+        return self.verify(self.patch, path, body=body)
+
+    def replace_service_tags(self, project, service, tags):
+        path = self.build_path(
+            "project",
+            project,
+            "service",
+            service,
+            "tags",
+        )
+        body = {"tags": tags}
+        return self.verify(self.put, path, body=body)
 
     def get_services(self, project):
         return self.verify(


### PR DESCRIPTION
Tags are string key - string value pairs that can be attached to aiven
resources, initially to projects and services. This adds support for
managing project and service tags.

# About this change: What it does, why it matters

Adds support for a new API.


