### PR TITLE
Fix arg type to support card CVC with leading zero

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4558,7 +4558,7 @@ server_encryption_options:
         return response.json()["id"]
 
     @arg.json
-    @arg("--cvc", help="Credit card security code", type=int, required=True)
+    @arg("--cvc", help="Credit card security code", required=True)
     @arg("--exp-month", help="Card expiration month (1-12)", type=int, required=True)
     @arg("--exp-year", help="Card expiration year", type=int, required=True)
     @arg("--name", help="Name on card", required=True)


### PR DESCRIPTION
Card security code can start with zero, so handling it as integer is not
appropriate. Use string so that leading zeroes are preserved.

# About this change: What it does, why it matters

Allows adding card when CVC starts with zero


