### PR TITLE
Add --use-karapace to service update args

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3888,6 +3888,12 @@ ssl.truststore.type=JKS
         help="Set automatic maintenance window's start time (HH:MM:SS)",
     )
     @arg(
+        "--use-karapace",
+        action="store_true",
+        default=None,
+        help="Use Karapace for Schema Registry and Kafka REST API",
+    )
+    @arg(
         "--enable-termination-protection",
         action="store_true",
         help="Enable termination protection",
@@ -3910,6 +3916,7 @@ ssl.truststore.type=JKS
     def service__update(self):
         """Update service settings"""
         powered = self._get_powered()
+        karapace = self.args.use_karapace
         project = self.get_project()
         service = self.client.get_service(project=project, service=self.args.service_name)
         plan = self.args.plan or service["plan"]
@@ -3946,6 +3953,7 @@ ssl.truststore.type=JKS
                 maintenance=maintenance or None,
                 plan=plan,
                 disk_space_mb=self.args.disk_space_mb,
+                karapace=karapace,
                 powered=powered,
                 project=project,
                 service=self.args.service_name,
@@ -3954,8 +3962,11 @@ ssl.truststore.type=JKS
                 project_vpc_id=project_vpc_id,
             )
         except client.Error as ex:
-            print(ex.response.text)
-            raise argx.UserError("Service '{}/{}' update failed".format(project, self.args.service_name))
+            try:
+                error_message = ex.response.json()["message"]
+            except ValueError:
+                error_message = ex.response.text
+            raise argx.UserError("Service '{}/{}' update failed: {}".format(project, self.args.service_name, error_message))
 
     @arg("project_name", help="Project name")
     @arg.cloud

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1332,6 +1332,7 @@ class AivenClient(AivenClientBase):
         user_config=None,
         plan=None,
         disk_space_mb=None,
+        karapace=None,
         powered=None,
         termination_protection=None,
         project_vpc_id=UNDEFINED,
@@ -1348,6 +1349,8 @@ class AivenClient(AivenClientBase):
             body["disk_space_mb"] = disk_space_mb
         if powered is not None:
             body["powered"] = powered
+        if karapace is not None:
+            body["karapace"] = karapace
         if user_config is not None:
             body["user_config"] = user_config
         if project_vpc_id is not UNDEFINED:


### PR DESCRIPTION
# About this change: What it does, why it matters

Kafka service can be switched to Karapace only for REST API and schema registry if not yet migrated.

