### PR TITLE
Show "upgrade required" when EOL notification is of "warning" level

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -987,7 +987,9 @@ class AivenCLI(argx.CommandLineTool):
                 if notification["type"] == "service_end_of_life":
                     eol_time = parse_iso8601(notification["metadata"]["service_end_of_life_time"])
                     eol_date = eol_time.date().isoformat()
-                    notifications.append(f"EOL: {eol_date} Upgrade available")
+                    is_urgent = notification["level"] == "warning"
+                    upgrade_urgency = "required" if is_urgent else "available"
+                    notifications.append(f"EOL: {eol_date} Upgrade {upgrade_urgency}")
 
             return notifications
         else:


### PR DESCRIPTION
The EOL notification formatting for `service list` was statically displaying:

`EOL: 2021-11-11 Upgrade available`

when an EOL notification was present on a service, it will now show:

`EOL: 2021-11-11 Upgrade required`

when the notification is of "warning" level, matching what the web UI does.


