### PR TITLE
add support for unpinned connection pools [BF-552]

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1558,7 +1558,7 @@ class AivenCLI(argx.CommandLineTool):
     @arg.service_name
     @arg("--pool-name", help="Connection pool name", required=True)
     @arg("--dbname", help="Service database name", required=True)
-    @arg("--username", help="Service username", required=True)
+    @arg("--username", help="Service username")
     @arg("--pool-size", type=int, help="Connection pool size")
     @arg("--pool-mode", help="Connection pool mode")
     @arg.json
@@ -1578,21 +1578,25 @@ class AivenCLI(argx.CommandLineTool):
     @arg.service_name
     @arg("--pool-name", help="Connection pool name", required=True)
     @arg("--dbname", help="Service database name")
-    @arg("--username", help="Service username")
+    @arg("--username", help="Service username (set to empty string to remove the pool username)")
     @arg("--pool-size", type=int, help="Connection pool size")
     @arg("--pool-mode", help="Connection pool mode")
     @arg.json
     def service__connection_pool_update(self):
         """Update a connection pool for a given PostgreSQL service"""
-        self.client.update_service_connection_pool(
+        kwargs = dict(
             project=self.get_project(),
             service=self.args.service_name,
             pool_name=self.args.pool_name,
             dbname=self.args.dbname,
-            username=self.args.username,
             pool_size=self.args.pool_size,
             pool_mode=self.args.pool_mode,
         )
+
+        if self.args.username is not None:
+            kwargs["username"] = self.args.username if self.args.username != "" else None
+
+        self.client.update_service_connection_pool(**kwargs)
 
     @arg.project
     @arg.service_name

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     __version__ = "UNKNOWN"
 
+UNCHANGED = object()  # used as a sentinel value
+
 
 class Error(Exception):
     """Request error"""
@@ -221,11 +223,13 @@ class AivenClient(AivenClientBase):
         service,
         pool_name,
         dbname,
-        username,
+        username=None,
         pool_size=None,
         pool_mode=None,
     ):
-        body = {"database": dbname, "username": username, "pool_name": pool_name}
+        body = {"database": dbname, "pool_name": pool_name}
+        if username:
+            body["username"] = username
         if pool_size:
             body["pool_size"] = pool_size
         if pool_mode:
@@ -242,12 +246,12 @@ class AivenClient(AivenClientBase):
         service,
         pool_name,
         dbname=None,
-        username=None,
+        username=UNCHANGED,
         pool_size=None,
         pool_mode=None,
     ):
         body = {}
-        if username is not None:
+        if username is not UNCHANGED:
             body["username"] = username
         if dbname is not None:
             body["database"] = dbname


### PR DESCRIPTION
We support unpinned connection pools (reusing the pool user to connect
to the database) on the platform for a while now. This adds client support
for creating unpinned pools and for unpinning existing pools.