### PR TITLE
flink: support new versions of API methods [HH-690]

### DIFF
--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1031,8 +1031,12 @@ class AivenClient(AivenClientBase):
         table_name,
         schema_sql,
         kafka_topic=None,
+        kafka_connector_type=None,
+        kafka_key_format=None,
+        kafka_key_fields=None,
+        kafka_value_format=None,
+        kafka_startup_mode=None,
         jdbc_table=None,
-        partitioned_by=None,
         like_options=None
     ):
         path = self.build_path(
@@ -1050,10 +1054,18 @@ class AivenClient(AivenClientBase):
         }
         if kafka_topic:
             body["kafka_topic"] = kafka_topic
+        if kafka_connector_type:
+            body["kafka_connector_type"] = kafka_connector_type
+        if kafka_key_format:
+            body["kafka_key_format"] = kafka_key_format
+        if kafka_key_fields:
+            body["kafka_key_fields"] = kafka_key_fields
+        if kafka_value_format:
+            body["kafka_value_format"] = kafka_value_format
+        if kafka_startup_mode:
+            body["kafka_startup_mode"] = kafka_startup_mode
         if jdbc_table:
             body["jdbc_table"] = jdbc_table
-        if partitioned_by:
-            body["partitioned_by"] = partitioned_by
         if like_options:
             body["like_options"] = like_options
         return self.verify(self.post, path, body=body)


### PR DESCRIPTION
In Flink backend were added new options for Flink table creations:
- key format for kafka
- value format for kafka
- kafka conntector type
- startup mode for kafka
- detaled columns type for tables

Colums info is in a json array and look a bit ugly and make reading harder in a table layout.
That is why, I did incude colums when customer request one table info or create a table but excluded from a table lists:

With columns:

![Screenshot from 2021-11-18 09-53-43](https://user-images.githubusercontent.com/2606653/142376486-5e4c9323-60a2-410f-89ea-643a5b6ba699.png)

Without columns:
![Screenshot from 2021-11-18 09-53-28](https://user-images.githubusercontent.com/2606653/142376644-1bf4d61e-232c-4b87-8fb6-47076931174d.png)

Without columns it is easier to read table ids and schema.
