### PR TITLE
Add command to acknowledge certificate update

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1894,6 +1894,18 @@ ssl.truststore.type=JKS
     @arg.project
     @arg.service_name
     @arg("--username", help="Service user username", required=True)
+    @arg.json
+    def service__user_creds_acknowledge(self):
+        """Acknowledge that service user certificates have been updated"""
+        self.client.acknowledge_service_user_certificate(
+            project=self.get_project(),
+            service=self.args.service_name,
+            username=self.args.username,
+        )
+
+    @arg.project
+    @arg.service_name
+    @arg("--username", help="Service user username", required=True)
     @arg("--new-password", help="New password for service user")
     @arg.json
     def service__user_password_reset(self):

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -296,6 +296,11 @@ class AivenClient(AivenClientBase):
         path = self.build_path("project", project, "service", service, "user", username)
         return self.verify(self.get, path, result_key="user")
 
+    def acknowledge_service_user_certificate(self, project, service, username):
+        path = self.build_path("project", project, "service", service, "user", username)
+        body = {"operation": "acknowledge-renewal"}
+        return self.verify(self.put, path, body=body)
+
     def reset_service_user_password(self, project, service, username, password):
         path = self.build_path("project", project, "service", service, "user", username)
         body = {"operation": "reset-credentials"}


### PR DESCRIPTION
# About this change: What it does, why it matters

When a user certificate is renewed we email the project contacts to advise them to update the certificates in their Kafka clients. WE may do this periodically. There is a new API call to indicate that this step has been done and avoid follow-up emails. This PR adds a CLI command to invoke the API. The command is:
```
avn service user-creds-acknowledge ${SERVICE_NAME} --username ${USERNAME}
```

This name matches the CLI command to download the credentials: `user-creds-download`