### PR TITLE
pg: don't hard code major versions in upgrade_check task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-short_ver = 2.14.5
+short_ver = 2.14.6
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 generated = aiven/client/version.py
 PYTHON ?= python3

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2498,7 +2498,7 @@ ssl.truststore.type=JKS
     @arg(
         "--target-version",
         help="Upgrade target version",
-        choices=["10", "11", "12", "13"],
+        type=int,
         required=False,
     )
     @arg(
@@ -2520,7 +2520,7 @@ ssl.truststore.type=JKS
                 raise argx.UserError("--target-version is required for this operation")
             body = {
                 "task_type": self.args.operation,
-                "target_version": self.args.target_version,
+                "target_version": str(self.args.target_version),
             }
         elif self.args.operation == "migration_check":
             if not self.args.source_service_uri:


### PR DESCRIPTION
Instead of hard coding the supported versions just make sure the version
consists of digits only. The API will not accept invalid versions anyway.
This will allow performing the upgrade_check for - and subsequently
upgrading to - pg14 (and upcoming versions, as soon as they are offered).