### PR TITLE
Add dark-matter team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@aiven/team-dark-matter


### PR DESCRIPTION
# About this change: What it does, why it matters

This change should make PR reviews faster.



