### PR TITLE
Update broken certifi link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Requirements:
 *  For Windows and OSX, certifi_ is also needed
 
 .. _`Requests`: http://www.python-requests.org/
-.. _`certifi`: https://certifi.io/
+.. _`certifi`: https://github.com/certifi/python-certifi
 
 .. _installation:
 


### PR DESCRIPTION
# About this change: What it does, why it matters

Changed domain for certifi to go to Github repo for python package (direct link to certifi.io  returns a 403)


