### PR TITLE
flink: add opensearch_index to create table parameters

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3174,6 +3174,7 @@ ssl.truststore.type=JKS
         choices=["earliest-offset", "latest-offset"]
     )
     @arg("--jdbc-table", required=False, help="Table name in Database, used as a source/sink. (PG integration only)")
+    @arg("--opensearch-index", required=False, help="OpenSearch index name. (OpenSearch integration only)")
     @arg(
         "-l",
         "--like-options",
@@ -3206,6 +3207,7 @@ ssl.truststore.type=JKS
                 self.args.kafka_value_format,
                 self.args.kafka_startup_mode,
                 self.args.jdbc_table,
+                self.args.opensearch_index,
                 self.args.like_options,
             )
             self.print_response([new_table], json=self.args.json, table_layout=layout)

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1042,6 +1042,7 @@ class AivenClient(AivenClientBase):
         kafka_value_format=None,
         kafka_startup_mode=None,
         jdbc_table=None,
+        opensearch_index=None,
         like_options=None
     ):
         path = self.build_path(
@@ -1071,6 +1072,8 @@ class AivenClient(AivenClientBase):
             body["kafka_startup_mode"] = kafka_startup_mode
         if jdbc_table:
             body["jdbc_table"] = jdbc_table
+        if opensearch_index:
+            body["opensearch_index"] = opensearch_index
         if like_options:
             body["like_options"] = like_options
         return self.verify(self.post, path, body=body)


### PR DESCRIPTION
Add `opensearch_index` parameter to Flink table create API.

Testing:
```
$ ./scripts/avn service flink table create --project systest-project flink-flink-e2e-os-s068untw "d247af5d-daec-4629-a7bf-699f7201539f"  --opensearch-index index1 -s "id INT" -n "t1"
INTEGRATION_ID                        TABLE_ID                              TABLE_NAME  SCHEMA_SQL  COLUMNS                                             
====================================  ====================================  ==========  ==========  ====================================================
d247af5d-daec-4629-a7bf-699f7201539f  37fa3ba1-28d4-4a10-bc49-adda8b1d1a4a  t1          id INT      {"data_type": "INT", "name": "id", "nullable": true}
```

And the table `t1` can be seen in the Console UI, in the tables list when creating a job.

`--help` gives you this:

```
  --opensearch-index OPENSEARCH_INDEX
                        OpenSearch index name. (OpenSearch integration only)
```
