### PR TITLE
typing: add type checks for the first module

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,9 @@ jobs:
       - id: flake8
         run: make flake8
 
+      - id: mypy
+        run: make mypy
+
       - id: pyLint
         run: make pylint
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all: $(generated)
 aiven/client/version.py: .git/index
 	$(PYTHON) version.py $@
 
-test: flake8 pylint pytest
+test: flake8 mypy pylint pytest
 
 reformat:
 	$(PYTHON) -m isort --recursive $(PYTHON_DIRS)
@@ -29,6 +29,9 @@ validate-style:
 flake8:
 	$(PYTHON) -m flake8 $(PYTHON_DIRS)
 
+mypy:
+	$(PYTHON) -m mypy $(PYTHON_DIRS)
+
 pylint:
 	$(PYTHON) -m pylint $(PYTHON_DIRS)
 
@@ -44,7 +47,7 @@ clean:
 
 build-dep-fedora:
 	sudo dnf install -y --best --allowerasing python3-devel python3-flake8 python3-requests \
-		tar rpmdevtools python3-pylint python3-isort python3-pytest
+		tar rpmdevtools python3-mypy python3-pylint python3-isort python3-pytest
 
 .PHONY: rpm
 rpm: $(RPM)
@@ -64,4 +67,4 @@ $(RPM): $(generated)
 install-rpm: $(RPM)
 	sudo dnf install $<
 
-.PHONY: build-dep-fedora clean coverage pytest pylint flake8 reformat test validate-style
+.PHONY: build-dep-fedora clean coverage pytest mypy pylint flake8 reformat test validate-style

--- a/aiven-client.spec
+++ b/aiven-client.spec
@@ -7,7 +7,7 @@ License:        ASL 2.0
 Source0:        rpm-src-aiven-client.tar
 BuildArch:      noarch
 Requires:       python3-requests
-BuildRequires:  python3-devel, python3-flake8, python3-pylint, python3-pytest
+BuildRequires:  python3-devel, python3-flake8, python3-mypy, python3-pylint, python3-pytest
 
 
 %description

--- a/aiven/__init__.py
+++ b/aiven/__init__.py
@@ -1,3 +1,3 @@
 from pkgutil import extend_path
 
-__path__ = extend_path(__path__, __name__)
+__path__ = extend_path(__path__, __name__)  # type: ignore  # mypy issue #1422

--- a/aiven/client/__main__.py
+++ b/aiven/client/__main__.py
@@ -1,7 +1,8 @@
 from .cli import AivenCLI
+from typing import NoReturn
 
 
-def main():
+def main() -> NoReturn:
     AivenCLI().main()
 
 

--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -3,7 +3,7 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 from aiven.client import envdefault, pretty
-from typing import Optional
+from typing import NoReturn, Optional
 
 import aiven.client.client
 import argparse
@@ -302,7 +302,7 @@ class CommandLineTool:  # pylint: disable=old-style-class
         self.pre_run(func)
         return func()  # pylint: disable=not-callable
 
-    def main(self, args=None):
+    def main(self, args=None) -> NoReturn:
         # TODO: configurable log level
         logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
         logging.getLogger("requests").setLevel(logging.WARNING)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,26 @@
+# Global configuration
+
+[mypy]
+python_version = 3.7
+warn_redundant_casts = True
+
+# Disable errors on the code which is not annotated yet
+
+[mypy-aiven.client.*]
+ignore_errors = True
+
+[mypy-tests.*]
+ignore_errors = True
+
+[mypy-aiven.client.__main__]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_no_return = True
+warn_unreachable = True
+strict_equality = True
+ignore_missing_imports = True
+

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,6 @@
 flake8
+# Lock mypy to the same version used in downstream build environments
+mypy==0.910
 # Lock pylint to the same version used in downstream build environments
 pylint==2.6.0
 pytest


### PR DESCRIPTION
# About this change: What it does, why it matters
This change is the beginning of fully annotating Aiven Client. Install
mypy, add mypy config file with everything ignored, except for the one
module, add target to Makefile, enable checks in GitHub Actions.

Partial implementation of #258.
