### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.7, 3.8, 3.9, pypy3]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Getting Started
 
 Requirements:
 
-*  Python 3.6 or later
+*  Python 3.7 or later
 
 *  Requests_
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
# About this change: What it does, why it matters

Python 3.6 recently reached its end-of-life:
https://devguide.python.org/devcycle/#end-of-life-branches
