### PR TITLE
Link contributing file to readme file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -425,6 +425,11 @@ For working with `kafkacat <https://github.com/edenhill/kafkacat>`_ (see also ou
 
   $ avn service user-kafka-java-creds --username avnadmin -p t0pS3cr3t <service>
 
+Contributing
+============
+
+Check the `CONTRIBUTING <https://github.com/aiven/aiven-client/blob/master/.github/CONTRIBUTING.md>`_ guide for details on how to contribute to this repository.
+
 Keep Reading
 ============
 


### PR DESCRIPTION
# About this change: What it does, why it matters
File is located:
https://github.com/aiven/aiven-client/blob/master/.github/CONTRIBUTING.md

It is easier to find when it is located on the README
as the intention is to provide information for new
contributors, so this section may be useful. 

Therefore, this PR proposes this.


