### PR TITLE
cli: fix service user-get command

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1754,13 +1754,14 @@ class AivenCLI(argx.CommandLineTool):
             project=self.get_project(), service=self.args.service_name, username=self.args.username
         )
         layout = [["username", "type"]]
-        if "access_control" in user:
-            layout[0].extend([
-                "access_control.redis_acl_keys",
-                "access_control.redis_acl_commands",
-                "access_control.redis_acl_categories",
-                "access_control.redis_acl_channels",
-            ])
+        for field in (
+            "redis_acl_keys",
+            "redis_acl_commands",
+            "redis_acl_categories",
+            "redis_acl_channels",
+        ):
+            if field in user.get("access_control", {}):
+                layout[0].append(f"access_control.{field}")
         self.print_response(user, single_item=True, format=self.args.format, json=self.args.json, table_layout=layout)
 
     @arg.project

--- a/aiven/client/pretty.py
+++ b/aiven/client/pretty.py
@@ -124,9 +124,9 @@ def yield_table(result, drop_fields=None, table_layout=None, header=True):
         for key, value in item.items():
             if key in drop_fields:
                 continue  # field will not be printed
-            if table_layout is not None and key not in flattened_table_layout:
-                continue  # table_layout has been specified but this field will not be printed
             for subkey, subvalue in iter_values(key, value):
+                if table_layout is not None and subkey not in flattened_table_layout:
+                    continue  # table_layout has been specified but this field will not be printed
                 formatted_row[subkey] = format_item(subkey, subvalue)
                 widths[subkey] = max(len(subkey), len(formatted_row[subkey]), widths.get(subkey, 1))
 


### PR DESCRIPTION
# About this change: What it does, why it matters

In `service__user_get()`, avoid displaying Redis ACLs if they aren't present in user data - this
was previously causing exceptions if displaying other types of user, e.g. a Postgres user:

```
  File "/home/hugh.cole-baker/Source/aiven-client/aiven/client/cli.py", line 1764, in service__user_get
    self.print_response(user, single_item=True, format=self.args.format, json=self.args.json, table_layout=layout)
  File "/home/hugh.cole-baker/Source/aiven-client/aiven/client/argx.py", line 257, in print_response
    pretty.print_table(
  File "/home/hugh.cole-baker/Source/aiven-client/aiven/client/pretty.py", line 168, in print_table
    for row in yield_table(result, drop_fields=drop_fields, table_layout=table_layout, header=header):
  File "/home/hugh.cole-baker/Source/aiven-client/aiven/client/pretty.py", line 141, in yield_table
    yield "  ".join(f.upper().ljust(widths[f]) for f in horizontal_fields)
  File "/home/hugh.cole-baker/Source/aiven-client/aiven/client/pretty.py", line 141, in <genexpr>
    yield "  ".join(f.upper().ljust(widths[f]) for f in horizontal_fields)
KeyError: 'access_control.redis_acl_keys'
```

Also, fix the logic in pretty.py which was previously always excluding Redis ACLs from being displayed in the table output, even for Redis users, because they were specified in the layout as `key.subkey` but anything which did not exactly match a `key` in the item was excluded/hidden. Use a `startswith()` match instead, to get this output, which was presumably what was intended:

```
python3 -m aiven.client service user-get --project dev-sandbox redis-hughcb-example --username myuser 
USERNAME  TYPE     ACCESS_CONTROL.REDIS_ACL_KEYS  ACCESS_CONTROL.REDIS_ACL_COMMANDS  ACCESS_CONTROL.REDIS_ACL_CATEGORIES  ACCESS_CONTROL.REDIS_ACL_CHANNELS
========  =======  =============================  =================================  ===================================  =================================
myuser    regular  key1, key2, key3               -get, +set                         +@all                                *
```


