### PR TITLE
Add support for service backup list API

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1308,6 +1308,15 @@ class AivenCLI(argx.CommandLineTool):
                     })
             self.print_response(collapsed, format=self.args.format, json=False, table_layout=layout)
 
+    @arg.project
+    @arg.service_name
+    @arg.json
+    def service__backup_list(self):
+        """List backups for service."""
+        backups = self.client.get_service_backups(project=self.get_project(), service=self.args.service_name)
+        layout = ["backup_name", "backup_time", "data_size", "storage_location"]
+        self.print_response(backups, json=self.args.json, table_layout=layout)
+
     def _get_project_ca(self):
         return self.client.get_project_ca(project=self.get_project())["certificate"]
 

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -347,6 +347,10 @@ class AivenClient(AivenClientBase):
             self.build_path("project", project, "integration_endpoint", endpoint_id),
         )
 
+    def get_service_backups(self, project, service):
+        path = self.build_path("project", project, "service", service, "backups")
+        return self.verify(self.get, path, result_key="backups")
+
     def get_service_integrations(self, project, service):
         path = self.build_path("project", project, "service", service, "integration")
         return self.verify(self.get, path, result_key="service_integrations")


### PR DESCRIPTION
This new API endpoint returns just the list of backups that exist for
a service. Items in the backup list now contain `storage_location` member
containing the name of the cloud in which the backup is stored.

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)


