### PR TITLE
Add type annotation for some files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean:
 
 build-dep-fedora:
 	sudo dnf install -y --best --allowerasing python3-devel python3-flake8 python3-requests \
-		tar rpmdevtools python3-mypy python3-pylint python3-isort python3-pytest
+		tar rpmdevtools python3-mypy python3-types-requests python3-pylint python3-isort python3-pytest
 
 .PHONY: rpm
 rpm: $(RPM)

--- a/aiven/client/session.py
+++ b/aiven/client/session.py
@@ -1,19 +1,19 @@
-from requests import adapters, Session
+from requests import adapters, models, Session
 from requests.structures import CaseInsensitiveDict
-from typing import Optional
+from typing import Any, Optional
 
 try:
-    from .version import __version__  # pylint: disable=no-name-in-module
+    from .version import __version__
 except ImportError:
     __version__ = "UNKNOWN"
 
 
 class AivenClientAdapter(adapters.HTTPAdapter):
-    def __init__(self, *args, timeout: Optional[int] = None, **kwargs):
+    def __init__(self, *args: Any, timeout: Optional[int] = None, **kwargs: Any) -> None:
         self.timeout = timeout
         super().__init__(*args, **kwargs)
 
-    def send(self, *args, **kwargs):  # pylint: disable=signature-differs
+    def send(self, *args: Any, **kwargs: Any) -> models.Response:  # pylint: disable=signature-differs
         if not kwargs.get("timeout"):
             kwargs["timeout"] = self.timeout
         return super().send(*args, **kwargs)

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,15 +4,7 @@
 python_version = 3.7
 warn_redundant_casts = True
 
-# Disable errors on the code which is not annotated yet
-
 [mypy-aiven.client.*]
-ignore_errors = True
-
-[mypy-tests.*]
-ignore_errors = True
-
-[mypy-aiven.client.__main__]
 ignore_errors = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
@@ -23,4 +15,75 @@ warn_no_return = True
 warn_unreachable = True
 strict_equality = True
 ignore_missing_imports = True
+
+[mypy-tests.*]
+ignore_errors = False
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_no_return = True
+warn_unreachable = True
+strict_equality = True
+ignore_missing_imports = True
+
+# Disable errors on the code which is not annotated yet
+
+[mypy-aiven.client.argx]
+ignore_errors = True
+
+[mypy-aiven.client.cli]
+ignore_errors = True
+
+[mypy-aiven.client.cliarg]
+ignore_errors = True
+
+[mypy-aiven.client.client]
+ignore_errors = True
+
+[mypy-aiven.client.connection_info.__init__]
+ignore_errors = True
+
+[mypy-aiven.client.connection_info._utils]
+ignore_errors = True
+
+[mypy-aiven.client.connection_info.common]
+ignore_errors = True
+
+[mypy-aiven.client.connection_info.kafka]
+ignore_errors = True
+
+[mypy-aiven.client.connection_info.pg]
+ignore_errors = True
+
+[mypy-aiven.client.pretty]
+ignore_errors = True
+
+[mypy-aiven.client.speller]
+ignore_errors = True
+
+[mypy-tests.__init__]
+ignore_errors = True
+
+[mypy-tests.test_argx]
+ignore_errors = True
+
+[mypy-tests.test_cli]
+ignore_errors = True
+
+[mypy-tests.test_cliarg]
+ignore_errors = True
+
+[mypy-tests.test_pretty]
+ignore_errors = True
+
+[mypy-tests.test_session]
+ignore_errors = True
+
+[mypy-tests.test_speller]
+ignore_errors = True
+
+[mypy-version]
+ignore_errors = True
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,8 @@
 flake8
 # Lock mypy to the same major version used in downstream build environments
 mypy>=0.931,<1.0
+# Lock types-requests to the same major version used in downstream build environments
+types-requests>=2.26.1,<3.0
 # Lock pylint to the same major version used in downstream build environments
 pylint>=2.12.2,<3.0
 pytest


### PR DESCRIPTION
Add type annotation on the following
files:
	aiven/client/common.py
	aiven/client/envdefault.py
	aiven/client/session.py
        aiven/client/version.py

Signed-off-by: laysa.uchoa <laysa.uchoa@aiven.io>
Co-authored-by: Roman Inflianskas <rominf@aiven.io>

# About this change: What it does, why it matters

It is related to this Issue: https://github.com/aiven/aiven-client/issues/258