### PR TITLE
Add option not to revoke token on logout

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -415,10 +415,11 @@ class AivenCLI(argx.CommandLineTool):
         else:
             self.log.info("No projects exists. You should probably create one with 'avn project create <name>'")
 
-    @arg()
+    @arg("--no-token-revoke", action="store_true", help="Do not revoke token")
     def user__logout(self):
         """Logout from current session"""
-        self.client.access_token_revoke(token_prefix=self._get_auth_token())
+        if not self.args.no_token_revoke:
+            self.client.access_token_revoke(token_prefix=self._get_auth_token())
         self._remove_auth_token_file()
 
     @arg.verbose

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -318,3 +318,13 @@ def test_get_project(caplog):
     with mock_config({"default_project": "project_1"}):
         assert build_aiven_cli(aiven_client).run(args=args) is None
     assert not caplog.text
+
+
+def test_user_logout():
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    assert build_aiven_cli(aiven_client).run(["user", "logout"]) is None
+    aiven_client.access_token_revoke.assert_called()
+
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    assert build_aiven_cli(aiven_client).run(["user", "logout", "--no-token-revoke"]) is None
+    aiven_client.access_token_revoke.assert_not_called()


### PR DESCRIPTION
# About this change: What it does, why it matters

Keep the current logout behavior by default, but make it possible not to
revoke the token on logout.

```
$ avn user logout --no-token-revoke
```

Fix #253.
