### PR TITLE
Use pypy-3.7 and pypy-3.8 on CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
# About this change: What it does, why it matters

`pypy3` stands for Python 3.6, which was dropped recently.


