### PR TITLE
Add support for new Flink table creation API

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3220,43 +3220,54 @@ ssl.truststore.type=JKS
 
     @arg.project
     @arg.service_name
-    @arg("integration_id", help="Service integration ID")
-    @arg("-n", "--table-name", required=True, help="Table name")
-    @arg("--kafka-topic", required=False, help="Topic name, used as a source/sink. (Kafka integration only)")
+    @arg("integration_id", default=None, nargs="?", help="Service integration ID (deprecated)")
+    @arg("-n", "--table-name", required=False, help="Table name (deprecated)")
+    @arg("--kafka-topic", required=False, help="Topic name, used as a source/sink. (Kafka integration only) (deprecated)")
     @arg(
         "--kafka-connector-type",
         required=False,
-        help="Kafka connector type (Kafka integration only)",
+        help="Kafka connector type (Kafka integration only) (deprecated)",
         choices=["upsert-kafka", "kafka"],
     )
     @arg(
         "--kafka-key-format",
         required=False,
-        help="Key format. (Kafka integration only)",
+        help="Key format. (Kafka integration only) (deprecated)",
         choices=["avro", "avro-confluent", "debezium-avro-confluent", "debezium-json", "json"],
     )
-    @arg("--kafka-key-fields", nargs="*", default=[], required=False, help="Key fields names used in table schema")
+    @arg(
+        "--kafka-key-fields",
+        nargs="*",
+        default=[],
+        required=False,
+        help="Key fields names used in table schema (Kafka integration only) (deprecated)"
+    )
     @arg(
         "--kafka-value-format",
         required=False,
-        help="Value format. (Kafka integration only)",
+        help="Value format. (Kafka integration only) (deprecated)",
         choices=["avro", "avro-confluent", "debezium-avro-confluent", "debezium-json", "json"],
     )
     @arg(
         "--kafka-startup-mode",
         required=False,
-        help="Kafka startup mode (Kafka integration only)",
+        help="Kafka startup mode (Kafka integration only) (deprecated)",
         choices=["earliest-offset", "latest-offset"],
     )
-    @arg("--jdbc-table", required=False, help="Table name in Database, used as a source/sink. (PG integration only)")
-    @arg("--opensearch-index", required=False, help="OpenSearch index name. (OpenSearch integration only)")
+    @arg(
+        "--jdbc-table",
+        required=False,
+        help="Table name in Database, used as a source/sink. (PG integration only) (deprecated)"
+    )
+    @arg("--opensearch-index", required=False, help="OpenSearch index name. (OpenSearch integration only) (deprecated)")
     @arg(
         "-l",
         "--like-options",
         required=False,
-        help="Clause can be used to create a table based on a definition of an existing table",
+        help="Clause can be used to create a table based on a definition of an existing table (deprecated)",
     )
-    @arg("-s", "--schema-sql", required=True, help="Source/Sink table schema")
+    @arg("-s", "--schema-sql", required=False, help="Source/Sink table schema (deprecated)")
+    @arg.json_path_or_string_parameter("--table-properties")
     @arg.json
     def service__flink__table__create(self):
         """Create a Flink table"""
@@ -3272,20 +3283,21 @@ ssl.truststore.type=JKS
         ]
         try:
             new_table = self.client.create_flink_table(
-                project_name,
-                self.args.service_name,
-                self.args.integration_id,
-                self.args.table_name,
-                self.args.schema_sql,
-                self.args.kafka_topic,
-                self.args.kafka_connector_type,
-                self.args.kafka_key_format,
-                self.args.kafka_key_fields,
-                self.args.kafka_value_format,
-                self.args.kafka_startup_mode,
-                self.args.jdbc_table,
-                self.args.opensearch_index,
-                self.args.like_options,
+                project=project_name,
+                service=self.args.service_name,
+                integration_id=self.args.integration_id,
+                table_name=self.args.table_name,
+                schema_sql=self.args.schema_sql,
+                kafka_topic=self.args.kafka_topic,
+                kafka_connector_type=self.args.kafka_connector_type,
+                kafka_key_format=self.args.kafka_key_format,
+                kafka_key_fields=self.args.kafka_key_fields,
+                kafka_value_format=self.args.kafka_value_format,
+                kafka_startup_mode=self.args.kafka_startup_mode,
+                jdbc_table=self.args.jdbc_table,
+                opensearch_index=self.args.opensearch_index,
+                like_options=self.args.like_options,
+                table_properties=self.args.table_properties,
             )
             self.print_response([new_table], json=self.args.json, table_layout=layout)
         except client.Error as ex:

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3220,54 +3220,7 @@ ssl.truststore.type=JKS
 
     @arg.project
     @arg.service_name
-    @arg("integration_id", default=None, nargs="?", help="Service integration ID (deprecated)")
-    @arg("-n", "--table-name", required=False, help="Table name (deprecated)")
-    @arg("--kafka-topic", required=False, help="Topic name, used as a source/sink. (Kafka integration only) (deprecated)")
-    @arg(
-        "--kafka-connector-type",
-        required=False,
-        help="Kafka connector type (Kafka integration only) (deprecated)",
-        choices=["upsert-kafka", "kafka"],
-    )
-    @arg(
-        "--kafka-key-format",
-        required=False,
-        help="Key format. (Kafka integration only) (deprecated)",
-        choices=["avro", "avro-confluent", "debezium-avro-confluent", "debezium-json", "json"],
-    )
-    @arg(
-        "--kafka-key-fields",
-        nargs="*",
-        default=[],
-        required=False,
-        help="Key fields names used in table schema (Kafka integration only) (deprecated)"
-    )
-    @arg(
-        "--kafka-value-format",
-        required=False,
-        help="Value format. (Kafka integration only) (deprecated)",
-        choices=["avro", "avro-confluent", "debezium-avro-confluent", "debezium-json", "json"],
-    )
-    @arg(
-        "--kafka-startup-mode",
-        required=False,
-        help="Kafka startup mode (Kafka integration only) (deprecated)",
-        choices=["earliest-offset", "latest-offset"],
-    )
-    @arg(
-        "--jdbc-table",
-        required=False,
-        help="Table name in Database, used as a source/sink. (PG integration only) (deprecated)"
-    )
-    @arg("--opensearch-index", required=False, help="OpenSearch index name. (OpenSearch integration only) (deprecated)")
-    @arg(
-        "-l",
-        "--like-options",
-        required=False,
-        help="Clause can be used to create a table based on a definition of an existing table (deprecated)",
-    )
-    @arg("-s", "--schema-sql", required=False, help="Source/Sink table schema (deprecated)")
-    @arg.json_path_or_string_parameter("--table-properties")
+    @arg.json_path_or_string("table_properties")
     @arg.json
     def service__flink__table__create(self):
         """Create a Flink table"""
@@ -3285,18 +3238,6 @@ ssl.truststore.type=JKS
             new_table = self.client.create_flink_table(
                 project=project_name,
                 service=self.args.service_name,
-                integration_id=self.args.integration_id,
-                table_name=self.args.table_name,
-                schema_sql=self.args.schema_sql,
-                kafka_topic=self.args.kafka_topic,
-                kafka_connector_type=self.args.kafka_connector_type,
-                kafka_key_format=self.args.kafka_key_format,
-                kafka_key_fields=self.args.kafka_key_fields,
-                kafka_value_format=self.args.kafka_value_format,
-                kafka_startup_mode=self.args.kafka_startup_mode,
-                jdbc_table=self.args.jdbc_table,
-                opensearch_index=self.args.opensearch_index,
-                like_options=self.args.like_options,
                 table_properties=self.args.table_properties,
             )
             self.print_response([new_table], json=self.args.json, table_layout=layout)

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -47,33 +47,6 @@ def json_path_or_string(param_name: str) -> Callable[[Callable[[CommandLineTool]
     return wrapper
 
 
-def json_path_or_string_parameter(param_name):
-    """JSON parameter handler"""
-
-    def wrapper(fun):
-        arg(
-            param_name,
-            help="JSON string or path (preceded by '@') to a JSON configuration file",
-        )(fun)
-
-        @wraps(fun)
-        def wrapped(self):
-            sanitized_param_name = param_name.replace("--", "").replace("-", "_")
-            try:
-                setattr(
-                    self.args,
-                    sanitized_param_name,
-                    get_json_config(getattr(self.args, sanitized_param_name, "")),
-                )
-            except jsonlib.decoder.JSONDecodeError as err:
-                raise UserError from err
-            return fun(self)
-
-        return wrapped
-
-    return wrapper
-
-
 def user_config_json() -> Callable[[Callable[[CommandLineTool], T]], Callable[[CommandLineTool], T]]:
     """User config that accepts arbitrary JSON"""
 
@@ -217,7 +190,6 @@ arg.vat_id = arg("--vat-id", help="VAT ID of an EU VAT area business")
 arg.verbose = arg("-v", "--verbose", help="Verbose output", action="store_true", default=False)
 arg.connector_name = arg("connector", help="Connector name")
 arg.json_path_or_string = json_path_or_string
-arg.json_path_or_string_parameter = json_path_or_string_parameter
 arg.subject = arg("--subject", required=True, help="Subject name")
 arg.version_id = arg("--version-id", required=True, help="Subject version")
 arg.compatibility = arg(

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -47,6 +47,33 @@ def json_path_or_string(param_name: str) -> Callable[[Callable[[CommandLineTool]
     return wrapper
 
 
+def json_path_or_string_parameter(param_name):
+    """JSON parameter handler"""
+
+    def wrapper(fun):
+        arg(
+            param_name,
+            help="JSON string or path (preceded by '@') to a JSON configuration file",
+        )(fun)
+
+        @wraps(fun)
+        def wrapped(self):
+            sanitized_param_name = param_name.replace("--", "").replace("-", "_")
+            try:
+                setattr(
+                    self.args,
+                    sanitized_param_name,
+                    get_json_config(getattr(self.args, sanitized_param_name, "")),
+                )
+            except jsonlib.decoder.JSONDecodeError as err:
+                raise UserError from err
+            return fun(self)
+
+        return wrapped
+
+    return wrapper
+
+
 def user_config_json() -> Callable[[Callable[[CommandLineTool], T]], Callable[[CommandLineTool], T]]:
     """User config that accepts arbitrary JSON"""
 
@@ -190,6 +217,7 @@ arg.vat_id = arg("--vat-id", help="VAT ID of an EU VAT area business")
 arg.verbose = arg("-v", "--verbose", help="Verbose output", action="store_true", default=False)
 arg.connector_name = arg("connector", help="Connector name")
 arg.json_path_or_string = json_path_or_string
+arg.json_path_or_string_parameter = json_path_or_string_parameter
 arg.subject = arg("--subject", required=True, help="Subject name")
 arg.version_id = arg("--version-id", required=True, help="Subject version")
 arg.compatibility = arg(

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1064,7 +1064,7 @@ class AivenClient(AivenClientBase):
         self,
         project: str,
         service: str,
-        table_properties: Dict[str, str],
+        table_properties: Mapping[str, str],
     ) -> Mapping:
         path = self.build_path(
             "project",

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1076,6 +1076,7 @@ class AivenClient(AivenClientBase):
         jdbc_table: Optional[str] = None,
         opensearch_index: Optional[str] = None,
         like_options: Optional[str] = None,
+        table_properties: Optional[Dict[str, str]] = None,
     ) -> Mapping:
         path = self.build_path(
             "project",
@@ -1085,29 +1086,32 @@ class AivenClient(AivenClientBase):
             "flink",
             "table",
         )
-        body = {
-            "integration_id": integration_id,
-            "name": table_name,
-            "schema_sql": schema_sql,
-        }
-        if kafka_topic:
-            body["kafka_topic"] = kafka_topic
-        if kafka_connector_type:
-            body["kafka_connector_type"] = kafka_connector_type
-        if kafka_key_format:
-            body["kafka_key_format"] = kafka_key_format
-        if kafka_key_fields:
-            body["kafka_key_fields"] = kafka_key_fields
-        if kafka_value_format:
-            body["kafka_value_format"] = kafka_value_format
-        if kafka_startup_mode:
-            body["kafka_startup_mode"] = kafka_startup_mode
-        if jdbc_table:
-            body["jdbc_table"] = jdbc_table
-        if opensearch_index:
-            body["opensearch_index"] = opensearch_index
-        if like_options:
-            body["like_options"] = like_options
+        if not table_properties:
+            body = {
+                "integration_id": integration_id,
+                "name": table_name,
+                "schema_sql": schema_sql,
+            }
+            if kafka_topic:
+                body["kafka_topic"] = kafka_topic
+            if kafka_connector_type:
+                body["kafka_connector_type"] = kafka_connector_type
+            if kafka_key_format:
+                body["kafka_key_format"] = kafka_key_format
+            if kafka_key_fields:
+                body["kafka_key_fields"] = kafka_key_fields
+            if kafka_value_format:
+                body["kafka_value_format"] = kafka_value_format
+            if kafka_startup_mode:
+                body["kafka_startup_mode"] = kafka_startup_mode
+            if jdbc_table:
+                body["jdbc_table"] = jdbc_table
+            if opensearch_index:
+                body["opensearch_index"] = opensearch_index
+            if like_options:
+                body["like_options"] = like_options
+        else:
+            body = table_properties
         return self.verify(self.post, path, body=body)
 
     def get_flink_table(self, project: str, service: str, table_id: str) -> Mapping:

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1064,19 +1064,7 @@ class AivenClient(AivenClientBase):
         self,
         project: str,
         service: str,
-        integration_id: str,
-        table_name: str,
-        schema_sql: str,
-        kafka_topic: Optional[str] = None,
-        kafka_connector_type: Optional[str] = None,
-        kafka_key_format: Optional[str] = None,
-        kafka_key_fields: Optional[str] = None,
-        kafka_value_format: Optional[str] = None,
-        kafka_startup_mode: Optional[str] = None,
-        jdbc_table: Optional[str] = None,
-        opensearch_index: Optional[str] = None,
-        like_options: Optional[str] = None,
-        table_properties: Optional[Dict[str, str]] = None,
+        table_properties: Dict[str, str],
     ) -> Mapping:
         path = self.build_path(
             "project",
@@ -1086,33 +1074,7 @@ class AivenClient(AivenClientBase):
             "flink",
             "table",
         )
-        if not table_properties:
-            body = {
-                "integration_id": integration_id,
-                "name": table_name,
-                "schema_sql": schema_sql,
-            }
-            if kafka_topic:
-                body["kafka_topic"] = kafka_topic
-            if kafka_connector_type:
-                body["kafka_connector_type"] = kafka_connector_type
-            if kafka_key_format:
-                body["kafka_key_format"] = kafka_key_format
-            if kafka_key_fields:
-                body["kafka_key_fields"] = kafka_key_fields
-            if kafka_value_format:
-                body["kafka_value_format"] = kafka_value_format
-            if kafka_startup_mode:
-                body["kafka_startup_mode"] = kafka_startup_mode
-            if jdbc_table:
-                body["jdbc_table"] = jdbc_table
-            if opensearch_index:
-                body["opensearch_index"] = opensearch_index
-            if like_options:
-                body["like_options"] = like_options
-        else:
-            body = table_properties
-        return self.verify(self.post, path, body=body)
+        return self.verify(self.post, path, body=table_properties)
 
     def get_flink_table(self, project: str, service: str, table_id: str) -> Mapping:
         path = self.build_path("project", project, "service", service, "flink", "table", table_id)


### PR DESCRIPTION
# About this change: What it does, why it matters

This PR adds the support of new table creation API for Aiven for Apache Flink service.
Command line has new parameter `--table-properties` which takes a JSON string or a path to JSON file.


Old API is removed.



