### PR TITLE
Add type annotations to `aiven.client.speller` and `tests/test_speller.py`

### DIFF
--- a/aiven/client/speller.py
+++ b/aiven/client/speller.py
@@ -3,22 +3,24 @@
 # Copyright (c) 2007-2016 Peter Norvig
 # MIT license: www.opensource.org/licenses/mit-license.php
 
+from typing import Container, Iterable, Iterator, Optional
 
-def suggest(word_to_check, known_words):
-    def get_correction(word):
+
+def suggest(word_to_check: str, known_words: Container[str]) -> Optional[str]:
+    def get_correction(word: str) -> Optional[str]:
         """Most probable spelling correction for word."""
         candidates = get_candidates(word)
         return next(iter(candidates)) if candidates else None
 
-    def get_candidates(word):
+    def get_candidates(word: str) -> Iterable[str]:
         """Generate possible spelling corrections for word."""
         return get_known([word]) or get_known(get_edits1(word)) or get_known(get_edits2(word)) or []
 
-    def get_known(words):
+    def get_known(words: Iterable[str]) -> Iterable[str]:
         """The subset of `words` that appear in the dictionary of WORDS."""
         return set(w for w in words if w in known_words)
 
-    def get_edits1(word):
+    def get_edits1(word: str) -> Iterable[str]:
         """All edits that are one edit away from `word`."""
         letters = "abcdefghijklmnopqrstuvwxyz_"
         splits = [(word[:i], word[i:]) for i in range(len(word) + 1)]
@@ -28,7 +30,7 @@ def suggest(word_to_check, known_words):
         inserts = [L + c + R for L, R in splits for c in letters]
         return set(deletes + transposes + replaces + inserts)
 
-    def get_edits2(word):
+    def get_edits2(word: str) -> Iterator[str]:
         """All edits that are two edits away from `word`."""
         return (e2 for e1 in get_edits1(word) for e2 in get_edits1(e1))
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -54,9 +54,6 @@ ignore_errors = True
 [mypy-aiven.client.pretty]
 ignore_errors = True
 
-[mypy-aiven.client.speller]
-ignore_errors = True
-
 [mypy-tests.__init__]
 ignore_errors = True
 
@@ -75,9 +72,5 @@ ignore_errors = True
 [mypy-tests.test_session]
 ignore_errors = True
 
-[mypy-tests.test_speller]
-ignore_errors = True
-
 [mypy-version]
 ignore_errors = True
-

--- a/tests/test_speller.py
+++ b/tests/test_speller.py
@@ -3,6 +3,7 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 from aiven.client.speller import suggest
+from typing import Container, Optional
 
 import pytest
 
@@ -37,5 +38,5 @@ SERVICE_TYPES = [
         ("asdf", SERVICE_TYPES, None),
     ],
 )
-def test_suggest(word_to_check, known_words, suggestion):
+def test_suggest(word_to_check: str, known_words: Container[str], suggestion: Optional[str]) -> None:
     assert suggest(word_to_check=word_to_check, known_words=known_words) == suggestion


### PR DESCRIPTION
Add type annotations to:

- [x] `aiven/client/speller.py`
- [x] `tests/test_speller.py`

Part of https://github.com/aiven/aiven-client/issues/258