### PR TITLE
Add initial support for creating OAuth2 apps

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5115,6 +5115,42 @@ server_encryption_options:
         )
         print(response["message"])
 
+    @arg.json
+    @arg.account_id
+    @arg("-n", "--name", required=True, help="OAuth2 application name")
+    @arg(
+        "--redirect-uri",
+        required=True,
+        help="Redirect URI",
+    )
+    @arg(
+        "-d",
+        "--description",
+        required=False,
+        help="App description",
+    )
+    def account__oauth2_client__create(self):
+        """Create new OAuth2 client."""
+        oauth2_client = self.client.create_oauth2_client(
+            self.args.account_id,
+            name=self.args.name,
+            description=self.args.description,
+        )
+        client_id = oauth2_client["client_id"]
+
+        try:
+            redirect = self.client.create_oauth2_client_redirect(self.args.account_id, client_id, self.args.redirect_uri)
+            secret = self.client.create_oauth2_client_secret(self.args.account_id, client_id)
+
+            oauth2_client["redirect_uri"] = redirect["redirect_uri"]
+            oauth2_client["secret"] = secret["secret"]
+        except Exception:
+            self.client.delete_oauth2_client(self.args.account_id, client_id)
+            raise
+
+        table_layout = ["client_id", "name", "redirect_uri", "secret"]
+        self.print_response(oauth2_client, json=self.args.json, single_item=True, table_layout=table_layout)
+
 
 if __name__ == "__main__":
     AivenCLI().main()

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2140,3 +2140,26 @@ class AivenClient(AivenClientBase):
             self.delete,
             self.build_path("account", account_id, "team", team_id, "project", project),
         )
+
+    def create_oauth2_client(self, account_id: str, name: str, description: Optional[str] = None) -> Mapping:
+        return self.verify(
+            self.post,
+            self.build_path("account", account_id, "oauth_client"),
+            body={"name": name, "description": description},
+        )
+
+    def delete_oauth2_client(self, account_id: str, client_id: str) -> Mapping:
+        return self.verify(
+            self.delete,
+            self.build_path("account", account_id, "oauth_client", client_id),
+        )
+
+    def create_oauth2_client_redirect(self, account_id: str, client_id: str, uri: str) -> Mapping:
+        return self.verify(
+            self.post,
+            self.build_path("account", account_id, "oauth_client", client_id, "redirect"),
+            body={"redirect_uri": uri},
+        )
+
+    def create_oauth2_client_secret(self, account_id: str, client_id: str) -> Mapping:
+        return self.verify(self.post, self.build_path("account", account_id, "oauth_client", client_id, "secret"), body={})


### PR DESCRIPTION
# About this change: What it does, why it matters

Adds ability to configure OAuth2 apps for users.
As we are moving to allow third-party providers to integrate with aiven services it's helpful to have convenient interface to configure oauth2 apps.


