### PR TITLE
Harden the GitHub Workflows [SECDEV-678]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,7 @@
 name: Build Aiven Client
 
+permissions: read-all
+
 on:
   push:
     branches:
@@ -21,6 +23,8 @@ jobs:
 
       - id: checkout-code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - id: prepare-python
         uses: actions/setup-python@v2
@@ -55,6 +59,8 @@ jobs:
     steps:
       - id: checkout-code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - id: prepare-python
         uses: actions/setup-python@v2
@@ -67,4 +73,3 @@ jobs:
           pip install pytest
           pip install -e .
           pytest -vv tests/
-

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,6 +1,9 @@
 # Based on https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 name: Publish to PyPI
+
+permissions: read-all
+
 on:
   push:
     tags:
@@ -14,6 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
       with:
+        persist-credentials: false
         fetch-depth: 0
 
     - name: Set up Python
@@ -39,6 +43,6 @@ jobs:
         test $(git for-each-ref --format='%(objecttype)' ${GITHUB_REF}) == tag
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295 # v1.5.0
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This patch improves security around GitHub Workflows:

For the `build.yml` workflow:

 * Set the default workflow permissions to `read` - because this workflow does not need to modify anything in the project.
 * Do not let `actions/checkout` persist (write to disk) the GitHub token - because this workflow does not need to modify anything in the project. And prevents other actions to look at the token.

For the `publish-pypi.yaml` workflow:

 * Set the default workflow permissions to `read` - because this workflow does not need to modify anything in the project.
 * Do not let `actions/checkout` persist (write to disk) the GitHub token - because this workflow does not need to modify anything in the project. And prevents other actions to look at the token.
 * Pin the [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) action to the commit hash of their last release (`v1.5`) instead of pulling in `master`.

The other workflows only use trusted (GitHub) actions - no changes were made.

Additional notes in SECDEV-678
