### PR TITLE
Do not use a VPC by default

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3786,7 +3786,8 @@ ssl.truststore.type=JKS
         action="store_const",
         const=True,
         default=UNDEFINED,
-        help="Do not put the service into a project VPC even if the project has one in the selected cloud. This is the default action",
+        help="Do not put the service into a project VPC even if the project has one in the selected cloud."
+        " This is the default action",
     )
     @arg(
         "--use-project-vpc",
@@ -4051,7 +4052,8 @@ ssl.truststore.type=JKS
         action="store_const",
         const=True,
         default=UNDEFINED,
-        help="Do not put the service into a project VPC even if the project has one in the selected cloud. This is the default action",
+        help="Do not put the service into a project VPC even if the project has one in the selected cloud."
+        " This is the default action",
     )
     @arg(
         "--use-project-vpc",

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3778,8 +3778,17 @@ ssl.truststore.type=JKS
     )
     @arg(
         "--no-project-vpc",
-        action="store_true",
-        help="Do not put the service into a project VPC even if the project has one in the selected cloud",
+        action="store_const",
+        const=True,
+        default=True,
+        help="Do not put the service into a project VPC even if the project has one in the selected cloud. This is the default action",
+    )
+    @arg(
+        "--use-project-vpc",
+        action="store_const",
+        const=False,
+        dest="no_project_vpc",
+        help="Put the service into a project VPC if the project has one in the selected cloud",
     )
     @arg(
         "--static-ip",
@@ -4033,8 +4042,17 @@ ssl.truststore.type=JKS
     )
     @arg(
         "--no-project-vpc",
-        action="store_true",
-        help="Do not put the service into a project VPC even if the project has one in the selected cloud",
+        action="store_const",
+        const=True,
+        default=True,
+        help="Do not put the service into a project VPC even if the project has one in the selected cloud. This is the default action",
+    )
+    @arg(
+        "--use-project-vpc",
+        action="store_const",
+        const=False,
+        dest="no_project_vpc",
+        help="Put the service into a project VPC if the project has one in the selected cloud",
     )
     @arg.force
     def service__update(self) -> None:

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5153,7 +5153,7 @@ server_encryption_options:
 
     @arg.json
     @arg.account_id
-    def account__oauth2_client__list(self):
+    def account__oauth2_client__list(self) -> None:
         """List OAuth2 client configuration."""
 
         oauth2_clients = self.client.list_oauth2_clients(self.args.account_id)
@@ -5163,7 +5163,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__get(self):
+    def account__oauth2_client__get(self) -> None:
         """Get an OAuth2 client configuration."""
 
         oauth2_client = self.client.get_oauth2_client(self.args.account_id, self.args.oauth2_client_id)
@@ -5173,7 +5173,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__delete(self):
+    def account__oauth2_client__delete(self) -> None:
         """Remove an OAuth2 client."""
 
         self.client.delete_oauth2_client(self.args.account_id, self.args.oauth2_client_id)
@@ -5181,7 +5181,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__redirect_list(self):
+    def account__oauth2_client__redirect_list(self) -> None:
         """List OAuth2 client redirects."""
 
         oauth2_client_redirects = self.client.list_oauth2_client_redirects(self.args.account_id, self.args.oauth2_client_id)
@@ -5192,7 +5192,7 @@ server_encryption_options:
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
     @arg("--redirect-uri", help="Redirect URI")
-    def account__oauth2_client__redirect_create(self):
+    def account__oauth2_client__redirect_create(self) -> None:
         """Add an allowed redirect URI to an OAuth2 client."""
 
         redirect = self.client.create_oauth2_client_redirect(
@@ -5206,7 +5206,7 @@ server_encryption_options:
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
     @arg("--redirect-uri-id", help="Redirect URI id", required=True)
-    def account__oauth2_client__redirect_delete(self):
+    def account__oauth2_client__redirect_delete(self) -> None:
         """Add an allowed redirect URI to an OAuth2 client."""
 
         self.client.delete_oauth2_client_redirect(
@@ -5216,7 +5216,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__secret_list(self):
+    def account__oauth2_client__secret_list(self) -> None:
         """List OAuth2 client secrets."""
 
         oauth2_client_secrets = self.client.list_oauth2_client_secrets(self.args.account_id, self.args.oauth2_client_id)
@@ -5226,7 +5226,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__secret_create(self):
+    def account__oauth2_client__secret_create(self) -> None:
         """List OAuth2 client secrets."""
 
         secret = self.client.create_oauth2_client_secret(self.args.account_id, self.args.oauth2_client_id)
@@ -5237,7 +5237,7 @@ server_encryption_options:
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
     @arg("--secret-id", help="Client secret id")
-    def account__oauth2_client__secret_delete(self):
+    def account__oauth2_client__secret_delete(self) -> None:
         """List OAuth2 client secrets."""
 
         self.client.delete_oauth2_client_secret(self.args.account_id, self.args.oauth2_client_id, self.args.secret_id)

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3709,10 +3709,18 @@ ssl.truststore.type=JKS
 
     def _get_service_project_vpc_id(self) -> Optional[Union[object, str]]:
         """Utility method for service_create and service_update"""
+        # no_project_vpc will be:
+        #
+        # * False if the user explicitly requested --no-project-vpc
+        # * True if the user explicitly requested --use-project-vpc
+        # * UNDEFINED otherwise, which we take to mean "no project vpc"
         if self.args.project_vpc_id is None:
             project_vpc_id = None if self.args.no_project_vpc else UNDEFINED
-        elif self.args.no_project_vpc:
-            raise argx.UserError("Only one of --project-vpc-id and --no-project-vpc can be specified")
+        elif self.args.no_project_vpc != UNDEFINED:
+            raise argx.UserError(
+                "Only one of --project-vpc-id and --no-project-vpc/"
+                "--use-project-vpc can be specified"
+            )
         else:
             project_vpc_id = self.args.project_vpc_id
         return project_vpc_id
@@ -3780,13 +3788,14 @@ ssl.truststore.type=JKS
         "--no-project-vpc",
         action="store_const",
         const=True,
-        default=True,
+        default=UNDEFINED,
         help="Do not put the service into a project VPC even if the project has one in the selected cloud. This is the default action",
     )
     @arg(
         "--use-project-vpc",
         action="store_const",
         const=False,
+        default=UNDEFINED,
         dest="no_project_vpc",
         help="Put the service into a project VPC if the project has one in the selected cloud",
     )
@@ -4044,13 +4053,14 @@ ssl.truststore.type=JKS
         "--no-project-vpc",
         action="store_const",
         const=True,
-        default=True,
+        default=UNDEFINED,
         help="Do not put the service into a project VPC even if the project has one in the selected cloud. This is the default action",
     )
     @arg(
         "--use-project-vpc",
         action="store_const",
         const=False,
+        default=UNDEFINED,
         dest="no_project_vpc",
         help="Put the service into a project VPC if the project has one in the selected cloud",
     )

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3717,10 +3717,7 @@ ssl.truststore.type=JKS
         if self.args.project_vpc_id is None:
             project_vpc_id = None if self.args.no_project_vpc else UNDEFINED
         elif self.args.no_project_vpc != UNDEFINED:
-            raise argx.UserError(
-                "Only one of --project-vpc-id and --no-project-vpc/"
-                "--use-project-vpc can be specified"
-            )
+            raise argx.UserError("Only one of --project-vpc-id and --no-project-vpc/" "--use-project-vpc can be specified")
         else:
             project_vpc_id = self.args.project_vpc_id
         return project_vpc_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -657,7 +657,7 @@ def test_vpc_args_no_project_vpc() -> None:
     assert cli.args.project_vpc_id is None
     assert cli.args.no_project_vpc is True
 
-    assert cli._get_service_project_vpc_id() is None
+    assert cli._get_service_project_vpc_id() is None  # pylint: disable=protected-access
 
 
 def test_vpc_args_use_project_vpc() -> None:
@@ -666,7 +666,7 @@ def test_vpc_args_use_project_vpc() -> None:
     assert cli.args.project_vpc_id is None
     assert cli.args.no_project_vpc is False
 
-    assert cli._get_service_project_vpc_id() is UNDEFINED
+    assert cli._get_service_project_vpc_id() is UNDEFINED  # pylint: disable=protected-access
 
 
 def test_vpc_args_project_vpc_id() -> None:
@@ -675,14 +675,14 @@ def test_vpc_args_project_vpc_id() -> None:
     assert cli.args.project_vpc_id == "27"
     assert cli.args.no_project_vpc == UNDEFINED
 
-    assert cli._get_service_project_vpc_id() == "27"
+    assert cli._get_service_project_vpc_id() == "27"  # pylint: disable=protected-access
 
 
 def test_vpc_args_bad_combination_use_project_vpc() -> None:
     cli = AivenCLI()
     cli.parse_args(["service", "create", "--service-type=pg", "--project-vpc-id=27", "--use-project-vpc", "service-name"])
     with pytest.raises(UserError) as excinfo:
-        cli._get_service_project_vpc_id()
+        cli._get_service_project_vpc_id()  # pylint: disable=protected-access
     assert str(excinfo.value).startswith("Only one of --project-vpc-id")
 
 
@@ -690,5 +690,5 @@ def test_vpc_args_bad_combination_no_project_vpc() -> None:
     cli = AivenCLI()
     cli.parse_args(["service", "create", "--service-type=pg", "--project-vpc-id=27", "--no-project-vpc", "service-name"])
     with pytest.raises(UserError) as excinfo:
-        cli._get_service_project_vpc_id()
+        cli._get_service_project_vpc_id()  # pylint: disable=protected-access
     assert str(excinfo.value).startswith("Only one of --project-vpc-id")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -655,7 +655,7 @@ def test_vpc_args_no_project_vpc() -> None:
     cli = AivenCLI()
     cli.parse_args(["service", "create", "--service-type=pg", "--no-project-vpc", "service-name"])
     assert cli.args.project_vpc_id is None
-    assert cli.args.no_project_vpc == True
+    assert cli.args.no_project_vpc is True
 
     assert cli._get_service_project_vpc_id() is None
 
@@ -664,7 +664,7 @@ def test_vpc_args_use_project_vpc() -> None:
     cli = AivenCLI()
     cli.parse_args(["service", "create", "--service-type=pg", "--use-project-vpc", "service-name"])
     assert cli.args.project_vpc_id is None
-    assert cli.args.no_project_vpc == False
+    assert cli.args.no_project_vpc is False
 
     assert cli._get_service_project_vpc_id() is UNDEFINED
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,8 +653,7 @@ def test_static_ips_list(capsys: CaptureFixture[str]) -> None:
 
 def test_vpc_args_no_project_vpc() -> None:
     cli = AivenCLI()
-    cli.parse_args(['service', 'create', '--service-type=pg',
-                    '--no-project-vpc', 'service-name'])
+    cli.parse_args(["service", "create", "--service-type=pg", "--no-project-vpc", "service-name"])
     assert cli.args.project_vpc_id is None
     assert cli.args.no_project_vpc == True
 
@@ -663,8 +662,7 @@ def test_vpc_args_no_project_vpc() -> None:
 
 def test_vpc_args_use_project_vpc() -> None:
     cli = AivenCLI()
-    cli.parse_args(['service', 'create', '--service-type=pg',
-                    '--use-project-vpc', 'service-name'])
+    cli.parse_args(["service", "create", "--service-type=pg", "--use-project-vpc", "service-name"])
     assert cli.args.project_vpc_id is None
     assert cli.args.no_project_vpc == False
 
@@ -673,27 +671,24 @@ def test_vpc_args_use_project_vpc() -> None:
 
 def test_vpc_args_project_vpc_id() -> None:
     cli = AivenCLI()
-    cli.parse_args(['service', 'create', '--service-type=pg',
-                    '--project-vpc-id=27', 'service-name'])
-    assert cli.args.project_vpc_id == '27'
+    cli.parse_args(["service", "create", "--service-type=pg", "--project-vpc-id=27", "service-name"])
+    assert cli.args.project_vpc_id == "27"
     assert cli.args.no_project_vpc == UNDEFINED
 
-    assert cli._get_service_project_vpc_id() == '27'
+    assert cli._get_service_project_vpc_id() == "27"
 
 
 def test_vpc_args_bad_combination_use_project_vpc() -> None:
     cli = AivenCLI()
-    cli.parse_args(['service', 'create', '--service-type=pg',
-                    '--project-vpc-id=27', '--use-project-vpc', 'service-name'])
+    cli.parse_args(["service", "create", "--service-type=pg", "--project-vpc-id=27", "--use-project-vpc", "service-name"])
     with pytest.raises(UserError) as excinfo:
         cli._get_service_project_vpc_id()
-    assert str(excinfo.value).startswith('Only one of --project-vpc-id')
+    assert str(excinfo.value).startswith("Only one of --project-vpc-id")
 
 
 def test_vpc_args_bad_combination_no_project_vpc() -> None:
     cli = AivenCLI()
-    cli.parse_args(['service', 'create', '--service-type=pg',
-                    '--project-vpc-id=27', '--no-project-vpc', 'service-name'])
+    cli.parse_args(["service", "create", "--service-type=pg", "--project-vpc-id=27", "--no-project-vpc", "service-name"])
     with pytest.raises(UserError) as excinfo:
         cli._get_service_project_vpc_id()
-    assert str(excinfo.value).startswith('Only one of --project-vpc-id')
+    assert str(excinfo.value).startswith("Only one of --project-vpc-id")


### PR DESCRIPTION
Make `--no-project-vpc` the default, for consistency with service creation (and update) in the console.

Add a new flag `--use-project-vpc` to get back to the previous behaviour.

Fixes: https://github.com/aiven/aiven-client/issues/290

# About this change: What it does, why it matters

When a new service is created at the console, it will be created in "Public Internet" even if there is a VPC available.

When `avn service create` is used to create a new service, it will default to using a VPC if there is one available in the target cloud. This is unexpected, and can lead to (for instance):
```
avn service cli <pg-service-name>
```
giving an error like
```
psql: error: could not translate host name "<pg-service-name>" to address: nodename nor servname provided, or not known
```

This change alters the default to act like the console, by making `--no-project-vpc` the default. It also introduces a new switch to allow getting the original behaviour.

(It effectively makes the value `no_project_vpc` into a 3-state value. We want to be able to tell when the user explicitly specified either `--no-project-vpc` or `--use-project-vpc` so that the code can still give an error if they also specify `--project-vpc-id=<N>`.)

I'm not 100% happy about adding a new flag, but I assume we do want to be able to use the previous default behaviour, and I did not want to remove/rename the existing flag.

# Testing

There are new tests at the end of `tests/test_cli.py`. As this is an interaction between three switches,  it seemed important to test that they did work the way I expected.

I've also tested manually. Using project `dev-sandbox` I did:

* `python -m aiven.client service create --service-type pg --cloud google-europe-north1 --plan hobbyist tibs-pg-vanilla`

   This created a service with "Public Internet", which is the desired result of this PR.

* `python -m aiven.client service create --service-type pg --cloud google-europe-north1 --plan hobbyist tibs-pg-novpc --no-project-vpc`

  This also created a service with "Public Internet", obeying the existing switch.

* `python -m aiven.client service create --service-type pg --cloud google-europe-north1 --plan hobbyist tibs-pg-vpc --use-project-vpc`

  This created a service with "Project VPC", obeying the new switch.
