### PR TITLE
Add missing type annotations to aiven cli oauth2 commands

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5126,7 +5126,7 @@ server_encryption_options:
 
     @arg.json
     @arg.account_id
-    def account__oauth2_client__list(self):
+    def account__oauth2_client__list(self) -> None:
         """List OAuth2 client configuration."""
 
         oauth2_clients = self.client.list_oauth2_clients(self.args.account_id)
@@ -5136,7 +5136,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__get(self):
+    def account__oauth2_client__get(self) -> None:
         """Get an OAuth2 client configuration."""
 
         oauth2_client = self.client.get_oauth2_client(self.args.account_id, self.args.oauth2_client_id)
@@ -5146,7 +5146,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__delete(self):
+    def account__oauth2_client__delete(self) -> None:
         """Remove an OAuth2 client."""
 
         self.client.delete_oauth2_client(self.args.account_id, self.args.oauth2_client_id)
@@ -5154,7 +5154,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__redirect_list(self):
+    def account__oauth2_client__redirect_list(self) -> None:
         """List OAuth2 client redirects."""
 
         oauth2_client_redirects = self.client.list_oauth2_client_redirects(self.args.account_id, self.args.oauth2_client_id)
@@ -5165,7 +5165,7 @@ server_encryption_options:
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
     @arg("--redirect-uri", help="Redirect URI")
-    def account__oauth2_client__redirect_create(self):
+    def account__oauth2_client__redirect_create(self) -> None:
         """Add an allowed redirect URI to an OAuth2 client."""
 
         redirect = self.client.create_oauth2_client_redirect(
@@ -5179,7 +5179,7 @@ server_encryption_options:
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
     @arg("--redirect-uri-id", help="Redirect URI id", required=True)
-    def account__oauth2_client__redirect_delete(self):
+    def account__oauth2_client__redirect_delete(self) -> None:
         """Add an allowed redirect URI to an OAuth2 client."""
 
         self.client.delete_oauth2_client_redirect(
@@ -5189,7 +5189,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__secret_list(self):
+    def account__oauth2_client__secret_list(self) -> None:
         """List OAuth2 client secrets."""
 
         oauth2_client_secrets = self.client.list_oauth2_client_secrets(self.args.account_id, self.args.oauth2_client_id)
@@ -5199,7 +5199,7 @@ server_encryption_options:
     @arg.json
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
-    def account__oauth2_client__secret_create(self):
+    def account__oauth2_client__secret_create(self) -> None:
         """List OAuth2 client secrets."""
 
         secret = self.client.create_oauth2_client_secret(self.args.account_id, self.args.oauth2_client_id)
@@ -5210,7 +5210,7 @@ server_encryption_options:
     @arg.account_id
     @arg("--oauth2-client-id", help="OAuth2 client id", required=True)
     @arg("--secret-id", help="Client secret id")
-    def account__oauth2_client__secret_delete(self):
+    def account__oauth2_client__secret_delete(self) -> None:
         """List OAuth2 client secrets."""
 
         self.client.delete_oauth2_client_secret(self.args.account_id, self.args.oauth2_client_id, self.args.secret_id)


### PR DESCRIPTION
Oauth2 commands were added in parallel with another commit adding typing to cli module and slipped through.

