### PR TITLE
Make package PEP 561 compatible

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+global-include *.typed
+
 include aiven/*.py
 include tests/*.py
 include scripts/*

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     license="Apache 2.0",
     name="aiven-client",
     packages=find_packages(exclude=["tests"]),
+    package_data={"aiven.client": ["py.typed"]},
     platforms=["POSIX", "MacOS", "Windows"],
     description="Aiven.io client library / command-line client",
     long_description=open("README.rst").read(),


### PR DESCRIPTION
# About this change: What it does, why it matters

Even though package was fully type annotated, it was not PEP 561 compatible:
https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages

This change fixes the issue.


