### PR TITLE
Adding connection-info kcat support in aiven-client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -468,7 +468,7 @@ Each project has its own CA cert, and other services (notably Kafka) use mutualT
 
   $ avn service user-creds-download --username avnadmin <service>
 
-For working with `kafkacat <https://github.com/edenhill/kafkacat>`_ (see also our `help article <https://help.aiven.io/en/articles/2607674-using-kafkacat>`_ ) or the command-line tools that ship with Kafka itself, a keystore and trustore are needed. By specifying which user's creds to use, and a secret, you can generate these via ``avn`` too::
+For working with `kcat <https://github.com/edenhill/kcat>`_ (see also our `help article <https://developer.aiven.io/docs/products/kafka/howto/kcat.html>`_ ) or the command-line tools that ship with Kafka itself, a keystore and trustore are needed. By specifying which user's creds to use, and a secret, you can generate these via ``avn`` too::
 
   $ avn service user-kafka-java-creds --username avnadmin -p t0pS3cr3t <service>
 

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1343,7 +1343,7 @@ class AivenCLI(argx.CommandLineTool):
             store = Store.skip
         return store
 
-    # This method should be deprecated and removed over time. Check service__connection_info__kcat
+    # Check service__connection_info__kcat
     @arg.project
     @arg.service_name
     @arg("-r", "--route", choices=("dynamic", "privatelink", "public"))

--- a/aiven/client/connection_info/kafka.py
+++ b/aiven/client/connection_info/kafka.py
@@ -104,7 +104,6 @@ class KafkaSASLConnectionInfo(KafkaConnectionInfo):
             raise ConnectionInfoError(
                 "Cannot format kafka connection info for service type {service_type}".format_map(service)
             )
-        
         try:
             info = find_component(
                 service["components"],
@@ -112,7 +111,6 @@ class KafkaSASLConnectionInfo(KafkaConnectionInfo):
                 privatelink_connection_id=privatelink_connection_id,
                 kafka_authentication_method="sasl",
             )
-            
             user = find_user(service, username)
             if "password" not in user:
                 raise ConnectionInfoError(f"Could not find password for username {username}")

--- a/aiven/client/connection_info/kafka.py
+++ b/aiven/client/connection_info/kafka.py
@@ -12,12 +12,18 @@ class KafkaConnectionInfo:  # pylint: disable=too-few-public-methods
     host: str
     port: int
 
-    def _kafkacat(
-        self, protocol: str, ca_path: str, extra: Sequence[str], store: Store, get_project_ca: Callable[[], str]
+    def _kcat(
+        self,
+        tool_name: str,
+        protocol: str,
+        ca_path: str,
+        extra: Sequence[str],
+        store: Store,
+        get_project_ca: Callable[[], str],
     ) -> Sequence[str]:
         store.handle(get_project_ca, ca_path)
         address = f"{self.host}:{self.port}"
-        return ["kafkacat", "-b", address, "-X", f"security.protocol={protocol}", "-X", f"ssl.ca.location={ca_path}", *extra]
+        return [tool_name, "-b", address, "-X", f"security.protocol={protocol}", "-X", f"ssl.ca.location={ca_path}", *extra]
 
 
 @dataclass
@@ -25,8 +31,14 @@ class KafkaCertificateConnectionInfo(KafkaConnectionInfo):
     client_cert: str
     client_key: str
 
-    def kafkacat(
-        self, store: Store, get_project_ca: Callable[[], str], ca_path: str, client_key_path: str, client_cert_path: str
+    def kcat(
+        self,
+        tool_name: str,
+        store: Store,
+        get_project_ca: Callable[[], str],
+        ca_path: str,
+        client_key_path: str,
+        client_cert_path: str,
     ) -> Sequence[str]:
         store.handle(lambda: self.client_cert, client_cert_path)
         store.handle(lambda: self.client_key, client_key_path)
@@ -37,7 +49,7 @@ class KafkaCertificateConnectionInfo(KafkaConnectionInfo):
             "-X",
             f"ssl.certificate.location={client_cert_path}",
         ]
-        return self._kafkacat("SSL", ca_path, extra, store, get_project_ca)
+        return self._kcat(tool_name, "SSL", ca_path, extra, store, get_project_ca)
 
     @classmethod
     def from_service(
@@ -100,7 +112,7 @@ class KafkaSASLConnectionInfo(KafkaConnectionInfo):
             raise ConnectionInfoError(f"Could not find password for username {username}")
         return cls(host=info["host"], port=info["port"], username=username, password=user["password"])
 
-    def kafkacat(self, store: Store, get_project_ca: Callable[[], str], ca_path: str) -> Sequence[str]:
+    def kcat(self, tool_name: str, store: Store, get_project_ca: Callable[[], str], ca_path: str) -> Sequence[str]:
         extra = [
             "-X",
             "sasl.mechanisms=SCRAM-SHA-256",
@@ -109,4 +121,4 @@ class KafkaSASLConnectionInfo(KafkaConnectionInfo):
             "-X",
             f"sasl.password={self.password}",
         ]
-        return self._kafkacat("SASL_SSL", ca_path, extra, store, get_project_ca)
+        return self._kcat(tool_name, "SASL_SSL", ca_path, extra, store, get_project_ca)


### PR DESCRIPTION
# About this change: What it does, why it matters


Kafkacat is the old name of the tool now named [kcat](https://github.com/edenhill/kcat), the PR adds the functions to retrieve the kcat call, we'll be then able to deprecate the `kafkacat` one and remove it safely some time in the future

