### PR TITLE
Temporary pin pip version in GitHub Actions to allow our way of versioning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - id: dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip==21.2.4
           pip install pytest
           pip install -e .
           pytest -vv tests/


### PR DESCRIPTION
# About this change: What it does, why it matters

pip==21.2.4 is the latest version that doesn't enforce PEP 440.

This is a temporary solution to unblock PRs.
