### PR TITLE
Add pypy-3.9 to GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
# About this change: What it does, why it matters

pypy has a version for Python 3.9, let's use it.
