### PR TITLE
Enable and disable authorization in Kafka REST proxy

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4049,6 +4049,30 @@ ssl.truststore.type=JKS
                 )
             ) from ex
 
+    def _schema_registry_authorization(self) -> Optional[bool]:
+        if self.args.enable_schema_registry_authorization and self.args.disable_schema_registry_authorization:
+            raise argx.UserError(
+                "--enable-schema-registry-authorization and --disable-schema-registry-authorization are mutually exclusive."
+            )
+        schema_registry_authorization = None
+        if self.args.enable_schema_registry_authorization:
+            schema_registry_authorization = True
+        if self.args.disable_schema_registry_authorization:
+            schema_registry_authorization = False
+        return schema_registry_authorization
+
+    def _rest_proxy_authorization(self) -> Optional[bool]:
+        if self.args.enable_rest_proxy_authorization and self.args.disable_rest_proxy_authorization:
+            raise argx.UserError(
+                "--enable-rest-proxy-authorization and --disable-rest-proxy-authorization are mutually exclusive."
+            )
+        rest_proxy_authorization = None
+        if self.args.enable_rest_proxy_authorization:
+            rest_proxy_authorization = True
+        if self.args.disable_rest_proxy_authorization:
+            rest_proxy_authorization = False
+        return rest_proxy_authorization
+
     @arg.project
     @arg.service_name
     @arg("--group-name", help="New service group (deprecated)")
@@ -4163,25 +4187,8 @@ ssl.truststore.type=JKS
         if self.args.group_name:
             self.log.warning("--group-name parameter is deprecated and has no effect")
 
-        if self.args.enable_schema_registry_authorization and self.args.disable_schema_registry_authorization:
-            raise argx.UserError(
-                "--enable-schema-registry-authorization and --disable-schema-registry-authorization are mutually exclusive."
-            )
-        schema_registry_authorization = None
-        if self.args.enable_schema_registry_authorization:
-            schema_registry_authorization = True
-        if self.args.disable_schema_registry_authorization:
-            schema_registry_authorization = False
-
-        if self.args.enable_rest_proxy_authorization and self.args.disable_rest_proxy_authorization:
-            raise argx.UserError(
-                "--enable-rest-proxy-authorization and --disable-rest-proxy-authorization are mutually exclusive."
-            )
-        rest_proxy_authorization = None
-        if self.args.enable_rest_proxy_authorization:
-            rest_proxy_authorization = True
-        if self.args.disable_rest_proxy_authorization:
-            rest_proxy_authorization = False
+        schema_registry_authorization = self._schema_registry_authorization()
+        rest_proxy_authorization = self._rest_proxy_authorization()
 
         try:
             self.client.update_service(

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4099,6 +4099,16 @@ ssl.truststore.type=JKS
         help="Disable termination protection",
     )
     @arg(
+        "--enable-rest-proxy-authorization",
+        action="store_true",
+        help="Enable Kafka REST proxy authorization",
+    )
+    @arg(
+        "--disable-rest-proxy-authorization",
+        action="store_true",
+        help="Disable Kafka REST proxy authorization",
+    )
+    @arg(
         "--enable-schema-registry-authorization",
         action="store_true",
         help="Enable Schema Registry authorization",
@@ -4163,6 +4173,16 @@ ssl.truststore.type=JKS
         if self.args.disable_schema_registry_authorization:
             schema_registry_authorization = False
 
+        if self.args.enable_rest_proxy_authorization and self.args.disable_rest_proxy_authorization:
+            raise argx.UserError(
+                "--enable-rest-proxy-authorization and --disable-rest-proxy-authorization are mutually exclusive."
+            )
+        rest_proxy_authorization = None
+        if self.args.enable_rest_proxy_authorization:
+            rest_proxy_authorization = True
+        if self.args.disable_rest_proxy_authorization:
+            rest_proxy_authorization = False
+
         try:
             self.client.update_service(
                 cloud=self.args.cloud,
@@ -4177,6 +4197,7 @@ ssl.truststore.type=JKS
                 termination_protection=termination_protection,
                 project_vpc_id=project_vpc_id,
                 schema_registry_authorization=schema_registry_authorization,
+                rest_proxy_authorization=rest_proxy_authorization,
             )
         except client.Error as ex:
             try:

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1397,6 +1397,7 @@ class AivenClient(AivenClientBase):
         termination_protection: Optional[bool] = None,
         project_vpc_id: Union[object, str] = UNDEFINED,
         schema_registry_authorization: Optional[bool] = None,
+        rest_proxy_authorization: Optional[bool] = None,
     ) -> Mapping:
         user_config = user_config or {}
         body: Dict[str, Any] = {}
@@ -1420,6 +1421,8 @@ class AivenClient(AivenClientBase):
             body["termination_protection"] = termination_protection
         if schema_registry_authorization is not None:
             body["schema_registry_authz"] = schema_registry_authorization
+        if rest_proxy_authorization is not None:
+            body["rest_proxy_authz"] = rest_proxy_authorization
 
         path = self.build_path("project", project, "service", service)
         return self.verify(self.put, path, body=body, result_key="service")


### PR DESCRIPTION
Add support for enabling and disable Kafka REST proxy authorization in a Kafka service. Adds two switches `--disable-rest-proxy-authorization` and `--enable-rest-proxy-authorization` to `service update` command.