### PR TITLE
Add 30s of timeout to the get Stripe tokens POST request

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4783,7 +4783,7 @@ server_encryption_options:
             "card[cvc]": cvc,
             "key": stripe_publishable_key,
         }
-        response = requests.post("https://api.stripe.com/v1/tokens", data=data)
+        response = requests.post("https://api.stripe.com/v1/tokens", data=data, timeout=30)
         if not response.ok:
             print(response.text)
             response.raise_for_status()


### PR DESCRIPTION
# What
- Add 30s of timeout to the get Stripe tokens POST request.

# Why
Failing CI jobs due this Pylint warning:
- https://github.com/aiven/aiven-client/runs/8135685364?check_suite_focus=true
- https://github.com/aiven/aiven-client/runs/8187706530?check_suite_focus=true

## References
- https://pylint.pycqa.org/en/latest/user_guide/messages/warning/missing-timeout.html
- https://aiven-io.slack.com/archives/C01F71NSJG2/p1662385160601659

