### PR TITLE
Proposal : option to use shtab for completion generation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -457,6 +457,16 @@ To use completions in bash, add following line to ``~/.bashrc``::
 
 For more information (including completions usage in other shells) see https://kislyuk.github.io/argcomplete/.
 
+avn also suports shtab. A slightly more lightweight option that can provide autocompletion within the Aiven CLI.
+
+  $ python3 -m pip install shtab
+
+To generate bash completion, you can run::
+
+  eval $(avn --print-completion zsh)
+
+For more information, check out https://pypi.org/project/shtab/
+
 Auth Helpers
 ------------
 

--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -45,6 +45,12 @@ except ImportError:
     ARGCOMPLETE_INSTALLED = False
 
 try:
+    import shtab
+    SHTAB_INSTALLED = True
+except ImportError:
+    SHTAB_INSTALLED = False
+
+try:
     from .version import __version__  # pylint: disable=no-name-in-module
 except ImportError:
     __version__ = "UNKNOWN"
@@ -225,10 +231,17 @@ class CommandLineTool:  # pylint: disable=old-style-class
 
         if ARGCOMPLETE_INSTALLED:
             argcomplete.autocomplete(self.parser)
+        
+        if SHTAB_INSTALLED:
+            shtab.add_argument_to(self.parser, ["-s", "--print-completion"])  # magic!
+
 
         ext_args = self.parser.parse_args(args=args)
         for ext in self._extensions:
             ext.args = ext_args
+
+    def get_main_parser(self):
+        return self.parser
 
     def pre_run(self, func: Callable) -> None:
         """Override in sub-class"""


### PR DESCRIPTION
# About this change: What it does, why it matters

Could be a draft for approval but was playing around with generating CLI docs from help strings and got a chance to play with `shtab`. Much lighter resource usage and does not execute underlying commands to generate completion. Added as an alternative option to `argcomplete` following the same method.

Not sure if this is better opened as a draft since it is technically a proposal


