### PR TITLE
Fix failing mypy error on CI build

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4,7 +4,7 @@
 # See the file `LICENSE` for details.
 from . import argx, client
 from aiven.client import AivenClient, envdefault
-from aiven.client.cliarg import arg  # type: ignore
+from aiven.client.cliarg import arg
 from aiven.client.common import UNDEFINED
 from aiven.client.connection_info.common import Store
 from aiven.client.connection_info.kafka import KafkaCertificateConnectionInfo, KafkaSASLConnectionInfo

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -2,7 +2,6 @@
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
-# type: ignore[attr-defined]
 from .argx import arg, CommandLineTool, UserError
 from functools import wraps
 from typing import Any, Callable, Dict, TypeVar

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,3 +32,11 @@ ignore_missing_imports = True
 
 [mypy-aiven.client.cliarg]
 warn_unused_ignores = False
+disable_error_code = attr-defined
+
+[mypy-aiven.client.cli]
+warn_unused_ignores = False
+disable_error_code = attr-defined
+
+[mypy-tests.test_cliarg]
+disable_error_code = attr-defined

--- a/tests/test_cliarg.py
+++ b/tests/test_cliarg.py
@@ -3,10 +3,9 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 
-# pylint: disable=no-member
 from _pytest.logging import LogCaptureFixture
 from aiven.client.argx import CommandLineTool
-from aiven.client.cliarg import arg  # type: ignore
+from aiven.client.cliarg import arg
 
 
 def test_user_config_json_error_json(caplog: LogCaptureFixture) -> None:


### PR DESCRIPTION
# What and why
- `mypy` versions `0.990` and `0.991` bring some breaking changes.

- We have to modify the way we ignore some errors in `cliarg` and `cli` modules, adding those to the `mypy.ini `config file should work

