### PR TITLE
client: add explicit export

### DIFF
--- a/aiven/client/__init__.py
+++ b/aiven/client/__init__.py
@@ -3,4 +3,6 @@
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
 
-from .client import AivenClient  # noqa
+from .client import AivenClient
+
+__all__ = ("AivenClient",)


### PR DESCRIPTION
In client projects, mypy complains about Client not being explicitly exported.

This change adds the explicit export.



