### PR TITLE
cli: add support for deleting pending invites

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -800,6 +800,14 @@ class AivenCLI(argx.CommandLineTool):
     @arg.json
     @arg.account_id
     @arg.team_id
+    @arg.email
+    def account__team__invite_delete(self) -> None:
+        """Delete pending invite from a team"""
+        self.client.delete_team_invite(self.args.account_id, self.args.team_id, self.args.email)
+
+    @arg.json
+    @arg.account_id
+    @arg.team_id
     @arg.user_id
     def account__team__user_delete(self) -> None:
         """Delete user from a team"""

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2115,6 +2115,9 @@ class AivenClient(AivenClientBase):
             result_key="account_invites",
         )
 
+    def delete_team_invite(self, account_id: str, team_id: str, email: str) -> Mapping:
+        return self.verify(self.delete, self.build_path("account", account_id, "team", team_id, "invites", email))
+
     def delete_team_member(self, account_id: str, team_id: str, user_id: str) -> Mapping:
         return self.verify(
             self.delete,


### PR DESCRIPTION
This patch adds support for `avn account team invite-delete` to delete a (pending) invite.

> In the API documentation this functionality is referred to as "Cancel pending user invite" - should the command follow that terminology and be `avn account team invite-cancel` ?