### PR TITLE
fix: pin setuptools to <66.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,6 +67,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: syphar/restore-virtualenv@v1
+        with:
+          requirement_files: requirements.dev.txt
+
       - id: dependencies
         run: |
           python -m pip install --upgrade pip==21.2.4


### PR DESCRIPTION
# About this change: What it does, why it matters

The setuptools 66.0.0 requires PEP 440 compatible version numbers. On the GitHub action the test phase fails as some package has non-conforming version string. The setuptools does not log the package, just the offending version string.
Fix is to pin the setuptools to previous version and wait for the upstream to be more lenient or Ubuntu runner to be fixed.

See: https://github.com/pypa/setuptools/issues/3772

Edit: reason looks to be that `pip-22.0.4` is installed regardless of pinning to `21.2.4`.
