### PR TITLE
fix: use virtualenv action to contain the build environment from runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,12 +22,12 @@ jobs:
     steps:
 
       - id: checkout-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - id: prepare-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -58,18 +58,24 @@ jobs:
 
     steps:
       - id: checkout-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - id: prepare-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - uses: syphar/restore-virtualenv@v1
+        with:
+          requirement_files: requirements.dev.txt
 
       - id: dependencies
         run: |
           python -m pip install --upgrade pip==21.2.4
+          pip install "setuptools<66.0.0"
           pip install pytest
           pip install -e .
           pytest -vv tests/
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,14 +67,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: requirements.dev.txt
-
       - id: dependencies
         run: |
-          python -m pip install --upgrade pip==21.2.4
-          pip install "setuptools<66.0.0"
           pip install pytest
           pip install -e .
           pytest -vv tests/


### PR DESCRIPTION
# About this change: What it does, why it matters

The GitHub runnners use such pip version that requires the version strings to conform with PEP 440. Use virtualenv and install older pip 21.2.4 inside.
The runner pip cannot be overridden.


