### PR TITLE
Pep 440 conformant versioning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,12 +22,12 @@ jobs:
     steps:
 
       - id: checkout-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - id: prepare-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -58,18 +58,19 @@ jobs:
 
     steps:
       - id: checkout-code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - id: prepare-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
-      - id: dependencies
+      - id: build-and-test
+        name: Build and test
         run: |
-          python -m pip install --upgrade pip==21.2.4
           pip install pytest
           pip install -e .
           pytest -vv tests/
+


### PR DESCRIPTION
# About this change: What it does, why it matters

The current GithHub Action runners use `pip` version that requires the versions string to conform to PEP 440.
The old `pip==21.2.4` install would require virtual environment wrapping as the runner `pip` cannot be changed.

Version string is reformatted to PEP 440 compliant from `git desribe --always` output.
In case of tagged version the version string is e.g. `2.18.0`, this is formatted to `2.18.0`
In case of detached head (like in GH action build) the version string  is `dfc4b4f`, this is formatted to `0.0.0+dfc4b4f`
In case of a branch the version string is `2.17.0-2-dfc4b4f`, this is formatted to `2.17.0+dfc4b4f`. Number of commits is removed.

