### PR TITLE
Fix main build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,7 @@ jobs:
       - id: checkout-code
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - id: prepare-python


### PR DESCRIPTION
# About this change: What it does, why it matters

Currently main build is broken:
1. Checkout Action does shallow fetch.
2. `pip` tries to install the package.
3. `setup.py` tries to generate version using `version.py`.
4. `version.py` executes `git describe`.
5. `git` outputs hash instead of tag + hash because the last commit is
   not tagged.
6. `version.py` expects tag + hash to extract the version and raises and
       exception.

This change changes fetching to get full history. 

Tested by cloning and observing `git describe` (locally).