### PR TITLE
Build against python 3.11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
# About this change: What it does, why it matters

Build against python 3.11.


