### PR TITLE
client: fix log level

### DIFF
--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -55,6 +55,7 @@ class AivenClientBase:  # pylint: disable=old-style-class
         http_handler.setFormatter(logging.Formatter("%(message)s"))
         self.http_log.addHandler(http_handler)
         self.http_log.propagate = False
+        self.http_log.setLevel(logging.INFO)
         if show_http:
             self.http_log.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
# About this change: What it does, why it matters

In the current implementation, if show_http is False, level ends up as NOTSET, which causes all messages to be processed.

By defaulting to INFO, we will hide all the debug messages unless show_http excplicitly is enabled.

