### PR TITLE
Fetch database list information from the canonical API endpoint

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2361,9 +2361,10 @@ ssl.truststore.type=JKS
     @arg.json
     def service__database_list(self) -> None:
         """List service databases"""
-        service = self.client.get_service(project=self.get_project(), service=self.args.service_name)
+        service = self.client.list_databases(project=self.get_project(), service=self.args.service_name)
+        database_names = [result["database_name"] for result in service["databases"]]
         layout = [["database"]]
-        self.print_response(service["databases"], json=self.args.json, table_layout=layout)
+        self.print_response(database_names, json=self.args.json, table_layout=layout)
 
     @arg.project
     @arg.service_name

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -299,6 +299,10 @@ class AivenClient(AivenClientBase):
         path = self.build_path("project", project, "service", service, "db", dbname)
         return self.verify(self.delete, path)
 
+    def list_databases(self, project: str, service: str) -> Mapping:
+        path = self.build_path("project", project, "service", service, "db")
+        return self.verify(self.get, path)
+
     def create_service_user(
         self, project: str, service: str, username: str, extra_params: Optional[Mapping[str, Any]] = None
     ) -> Mapping:


### PR DESCRIPTION
The database list information is currently extracted from the service results.
Change the implementation to use the canonical API endpoint, which has the best support for available service types out of the box.

# About this change: What it does, why it matters

The database list API endpoint is the canonical way to get the information.
