### PR TITLE
FIX: Handle dict value for column in table_layout

### DIFF
--- a/aiven/client/pretty.py
+++ b/aiven/client/pretty.py
@@ -131,11 +131,16 @@ def yield_table(  # noqa
         for key, value in item.items():
             if key in drop_fields:
                 continue  # field will not be printed
+            got_value_for_key = False
             for subkey, subvalue in iter_values(key, value):
                 if table_layout is not None and subkey not in flattened_table_layout:
                     continue  # table_layout has been specified but this field will not be printed
+                got_value_for_key = True
                 formatted_row[subkey] = format_item(subkey, subvalue)
                 widths[subkey] = max(len(subkey), len(formatted_row[subkey]), widths.get(subkey, 1))
+            if not got_value_for_key and (table_layout is None or key in flattened_table_layout):
+                formatted_row[key] = format_item(key, value)
+                widths[key] = max(len(key), len(formatted_row[key]), widths.get(key, 1))
 
     # default table layout is one row per item with sorted field names
     if table_layout is None:

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -161,7 +161,7 @@ def test_print_table_nested_dict() -> None:
 
     actual = get_output(rows, table_layout=["ip", "metric", "network"])
     expected = """
-IP            METRIC                 NETWORK       
+IP            METRIC                 NETWORK
 ============  =====================  ===============
 192.168.16.1  {"ping": 3, "qos": 1}  192.168.16.0/20
 10.0.0.1      {"ping": 100}          10.0.0.0/16
@@ -170,7 +170,7 @@ IP            METRIC                 NETWORK
 
     actual = get_output(rows, table_layout=["ip", "metric.qos", "network"])
     expected = """
-IP            METRIC.QOS  NETWORK       
+IP            METRIC.QOS  NETWORK
 ============  ==========  ===============
 192.168.16.1  1           192.168.16.0/20
 10.0.0.1                  10.0.0.0/16
@@ -179,7 +179,7 @@ IP            METRIC.QOS  NETWORK
 
     actual = get_output(rows, drop_fields=["function1", "function2", "next_hop_ip", "next_hop_mac"])
     expected = """
-IP            METRIC.PING  METRIC.QOS  NETWORK        
+IP            METRIC.PING  METRIC.QOS  NETWORK
 ============  ===========  ==========  ===============
 192.168.16.1  3            1           192.168.16.0/20
 10.0.0.1      100                      10.0.0.0/16

--- a/tests/test_pretty.py
+++ b/tests/test_pretty.py
@@ -121,6 +121,72 @@ IP            NETWORK          METRIC
         get_output(rows)
 
 
+def test_print_table_nested_dict() -> None:
+    """Print table, ensure we don't try to format non-visible field"""
+    rows = []
+    rows.append(
+        {
+            "ip": ipaddress.IPv4Address("192.168.16.1"),
+            "network": ipaddress.IPv4Network("192.168.16.0/20"),
+            "metric": {"qos": 1, "ping": 3},
+            "next_hop_ip": ipaddress.IPv4Address("192.168.16.2"),
+            "next_hop_mac": "0c:d0:f8:a3:04:31",
+            "function1": test_print_table,
+        }
+    )
+    rows.append(
+        {
+            "ip": ipaddress.IPv4Address("10.0.0.1"),
+            "network": ipaddress.IPv4Network("10.0.0.0/16"),
+            "metric": {"ping": 100},
+            "function2": test_print_table,
+        }
+    )
+
+    def get_output(
+        rows: Optional[ResultType],
+        *,
+        drop_fields: Optional[Collection[str]] = None,
+        table_layout: Optional[TableLayout] = None,
+    ) -> str:
+        temp_io = io.StringIO()
+        print_table(rows, drop_fields=drop_fields, table_layout=table_layout, file=temp_io)
+        temp_io.seek(0)
+        return temp_io.read()
+
+    def fuzzy_compare_assert(actual: str, expected: str) -> None:
+        cleanup_actual = re.sub(r" +$", "", actual.strip(), flags=re.MULTILINE)
+        cleanup_expected = re.sub(r" +$", "", expected.strip(), flags=re.MULTILINE)
+        assert cleanup_actual == cleanup_expected
+
+    actual = get_output(rows, table_layout=["ip", "metric", "network"])
+    expected = """
+IP            METRIC                 NETWORK       
+============  =====================  ===============
+192.168.16.1  {"ping": 3, "qos": 1}  192.168.16.0/20
+10.0.0.1      {"ping": 100}          10.0.0.0/16
+"""
+    fuzzy_compare_assert(actual, expected)
+
+    actual = get_output(rows, table_layout=["ip", "metric.qos", "network"])
+    expected = """
+IP            METRIC.QOS  NETWORK       
+============  ==========  ===============
+192.168.16.1  1           192.168.16.0/20
+10.0.0.1                  10.0.0.0/16
+"""
+    fuzzy_compare_assert(actual, expected)
+
+    actual = get_output(rows, drop_fields=["function1", "function2", "next_hop_ip", "next_hop_mac"])
+    expected = """
+IP            METRIC.PING  METRIC.QOS  NETWORK        
+============  ===========  ==========  ===============
+192.168.16.1  3            1           192.168.16.0/20
+10.0.0.1      100                      10.0.0.0/16
+"""
+    fuzzy_compare_assert(actual, expected)
+
+
 def test_yield_table() -> None:
     rows = [
         {


### PR DESCRIPTION
# Handle dict value for column in table_layout

Properly handle the case in which `table_layout` in `aiven.client.pretty.print_table` include a column whose value is a dict
object: in this case the dict will be serailized to a JSON string an added to the resulting table.

For example, consider the following:

```
rows = []
rows.append(
    {
        "ip": ipaddress.IPv4Address("192.168.16.1"),
        "network": ipaddress.IPv4Network("192.168.16.0/20"),
        "metric": {"qos": 1, "ping": 3},
        "next_hop_ip": ipaddress.IPv4Address("192.168.16.2"),
        "next_hop_mac": "0c:d0:f8:a3:04:31",
        "function1": test_print_table,
    }
)
rows.append(
    {
        "ip": ipaddress.IPv4Address("10.0.0.1"),
        "network": ipaddress.IPv4Network("10.0.0.0/16"),
        "metric": {"ping": 100},
        "function2": test_print_table,
    }
)
print_table(rows, table_layout=["ip", "metric", "network"])
```

The expected result would be:

```
IP            METRIC                 NETWORK
============  =====================  ===============
192.168.16.1  {"ping": 3, "qos": 1}  192.168.16.0/20
10.0.0.1      {"ping": 100}          10.0.0.0/16
```

At the moment, a `KeyError` will be raised, instead.  This PR fixes this case and makes the result matching the expected behaviour.

