### PR TITLE
Add support for Opensearch Security Management API

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3092,6 +3092,70 @@ ssl.truststore.type=JKS
 
     @arg.project
     @arg.service_name
+    def service__opensearch_security_management__status(self) -> None:
+        """Show status of the opensearch security"""
+        response = self.client.opensearch_security_get(
+            project=self.get_project(),
+            service=self.args.service_name,
+        )
+        available = response.get("security_plugin_available", False)
+        admin_enabled = response.get("security_plugin_admin_enabled", False)
+        message = response.get("message")
+        if not available:
+            if not message:
+                print("Opensearch Security is not available for the service")
+                return
+            print(message)
+            return
+        if admin_enabled:
+            print("Opensearch Security Management enabled")
+            return
+        print("Opensearch Security Management disabled")
+
+    @arg.project
+    @arg.service_name
+    def service__opensearch_security_management__set(self) -> None:
+        """Set the password for the opensearch security management"""
+        print("Opensearch Security Management is enabled by setting the password")
+        print("for the security management user. Once enabled normal Aiven service")
+        print("user and ACL management is no longer used and all user and access control")
+        print("can only be done using the native Opensearch Security API or dashboard.")
+        if self.confirm("this action is unrevertable. Proceed (y/N)? "):
+            passwd = self.enter_password(
+                prompt="Setup Opensearch Security Manager",
+                var="AIVEN_OS_SECOP_PASSWORD",
+                confirm=True,
+            )
+            response = self.client.opensearch_security_set(
+                project=self.get_project(),
+                service=self.args.service_name,
+                password=passwd,
+            )
+            print(response.get("message"))
+
+    @arg.project
+    @arg.service_name
+    def service__opensearch_security_management__reset(self) -> None:
+        """Reset the password for the opensearch security management"""
+        old_passwd = self.enter_password(
+            prompt="Old Opensearch Security Manager password",
+            var="AIVEN_OS_SECOP_PASSWORD",
+        )
+        new_passwd = self.enter_password(
+            prompt="New password",
+            var="AIVEN_OS_SECOP_NEW_PASSWORD",
+            confirm=True,
+        )
+        response = self.client.opensearch_security_reset(
+            project=self.get_project(),
+            service=self.args.service_name,
+            old_password=old_passwd,
+            new_password=new_passwd,
+        )
+        print(response.get("message"))
+
+    @arg.project
+    @arg.service_name
     def service__connector__available(self) -> None:
         """List available Kafka connectors"""
         project_name = self.get_project()

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -723,6 +723,26 @@ class AivenClient(AivenClientBase):
         path = self.build_path("project", project, "service", service, "elasticsearch", "acl")
         return self.verify(self.put, path, body={"elasticsearch_acl_config": acl_config})
 
+    def opensearch_security_get(self, project: str, service: str) -> Mapping:
+        return self.verify(
+            self.get,
+            self.build_path("project", project, "service", service, "opensearch", "security"),
+        )
+
+    def opensearch_security_set(self, project: str, service: str, password: str) -> Mapping:
+        return self.verify(
+            self.post,
+            self.build_path("project", project, "service", service, "opensearch", "security", "admin"),
+            body={"admin_password": password},
+        )
+
+    def opensearch_security_reset(self, project: str, service: str, old_password: str, new_password: str) -> Mapping:
+        return self.verify(
+            self.put,
+            self.build_path("project", project, "service", service, "opensearch", "security", "admin"),
+            body={"admin_password": old_password, "new_password": new_password},
+        )
+
     def add_service_kafka_acl(self, project: str, service: str, permission: str, topic: str, username: str) -> Mapping:
         return self.verify(
             self.post,


### PR DESCRIPTION
Opensearch security plugin for the Aiven for Opensearch has been introduced with API to query the status and enable the functionality. This adds the matching commands to the client.


