### PR TITLE
Set sub-command cli description 

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -207,7 +207,7 @@ class CommandLineTool:  # pylint: disable=old-style-class
                 self._cats[cat] = parser.add_subparsers()
             subparsers = self._cats[cat]
 
-        parser = subparsers.add_parser(cmd, help=func.__doc__, formatter_class=CustomFormatter)
+        parser = subparsers.add_parser(cmd, help=func.__doc__, description=func.__doc__, formatter_class=CustomFormatter)
         parser.set_defaults(func=func)
 
         for arg_prop in getattr(func, ARG_LIST_PROP, []):

--- a/tests/test_argx.py
+++ b/tests/test_argx.py
@@ -34,7 +34,10 @@ class SubCLI(CommandLineTool):
 
     @arg()
     def bbb(self) -> None:
-        """2"""
+        """2
+
+        With more explaining
+        """
 
     @arg()
     def ddd(self) -> None:
@@ -67,6 +70,19 @@ def test_extended_commands_remain_alphabetically_ordered() -> None:
 
     action_order = [item.dest for item in cli.subparsers._choices_actions]  # pylint: disable=protected-access
     assert action_order == ["aaa", "bbb", "bbc", "ccc", "ddd", "dde", "xxx", "yyy", "yyz"]
+
+
+def test_extended_command_has_function_help() -> None:
+    cli = TestCLI("testcli")
+    cli.extend_commands(cli)  # Force the CLI to have its full arg set at execution
+
+    sl = SubCLI("subcli")
+
+    cli.extend_commands(sl)
+
+    help = cli.subparsers.choices[sl.bbb.__name__].format_help()
+    assert sl.bbb.__doc__ is not None
+    assert sl.bbb.__doc__ in help
 
 
 class DescriptorCLI(CommandLineTool):


### PR DESCRIPTION
`Argparse` parsers use `description` to access the overall help for a command, unlike the `add_argument` calls which use the `help` attribute.

Without this, the general description on what a sub-command is to be used for is lost when running with `--help`

Documentation: https://docs.python.org/3/library/argparse.html#description



