### PR TITLE
fix organization id args to use `-` instead of `_`

### DIFF
--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -131,8 +131,8 @@ arg.min_insync_replicas = arg(
     type=int,
     help="Minimum required nodes In Sync Replicas (ISR) to produce to a partition (default: 1)",
 )
-arg.organization_id = arg("--organization_id", help="Organization identifier")
-arg.positional_organization_id = arg("organization_id", help="Organization identifier")
+arg.organization_id = arg("--organization-id", help="Organization identifier")
+arg.positional_organization_id = arg("organization-id", help="Organization identifier")
 arg.partitions = arg("--partitions", type=int, required=True, help="Number of partitions")
 arg.project = arg(
     "--project",


### PR DESCRIPTION
CLI args use `-` as word separator, some `_` slipped in.


