### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install pypa/build
       run: >-

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Getting Started
 
 Requirements:
 
-*  Python 3.7 or later
+*  Python 3.8 or later
 
 *  Requests_
 

--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -51,11 +51,7 @@ try:
 except ImportError:
     __version__ = "UNKNOWN"
 
-# cached_property only exists since python 3.8
-SKIP_EVALUATION_TYPES = (property,)
-if (sys.version_info[:2] >= (3, 8)) and hasattr(functools, "cached_property"):
-    SKIP_EVALUATION_TYPES += (functools.cached_property,)  # pylint: disable=no-member
-
+SKIP_EVALUATION_TYPES = (property, functools.cached_property)
 ARG_LIST_PROP = "_arg_list"
 LOG_FORMAT = "%(levelname)s\t%(message)s"
 

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5,6 +5,7 @@
 from . import argx, client
 from aiven.client import AivenClient, envdefault
 from aiven.client.cliarg import arg
+from aiven.client.client import Tag
 from aiven.client.common import UNDEFINED
 from aiven.client.connection_info.common import Store
 from aiven.client.connection_info.kafka import KafkaCertificateConnectionInfo, KafkaSASLConnectionInfo
@@ -88,7 +89,7 @@ tag_key_re = re.compile(r"[\w\-]+")
 tag_value_re = re.compile(r"[\w\-,. ]*")
 
 
-def parse_tag_str(kv: str) -> Mapping[str, str]:  # Can use TypedDict once moving to py >= 3.8
+def parse_tag_str(kv: str) -> Tag:
     k, v = (kv.split(sep="=", maxsplit=1) + [""])[:2]
 
     if not tag_key_re.fullmatch(k):

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -6,7 +6,7 @@ from .common import UNDEFINED
 from .session import get_requests_session
 from http import HTTPStatus
 from requests import Response
-from typing import Any, Callable, Collection, Dict, Mapping, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, Collection, Dict, Mapping, Optional, Sequence, Set, Tuple, Type, TypedDict, Union
 from urllib.parse import quote
 
 import json
@@ -35,6 +35,11 @@ class Error(Exception):
 
 class ResponseError(Exception):
     """Server returned error message"""
+
+
+class Tag(TypedDict):
+    key: str
+    value: str
 
 
 class AivenClientBase:  # pylint: disable=old-style-class
@@ -601,7 +606,7 @@ class AivenClient(AivenClientBase):
         retention_bytes: int,
         retention_hours: int,
         cleanup_policy: str,
-        tags: Optional[Sequence[Mapping[str, str]]] = None,
+        tags: Optional[Sequence[Tag]] = None,
     ) -> Mapping:
         body: Dict[str, Any] = {
             "cleanup_policy": cleanup_policy,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 # Global configuration
 
 [mypy]
-python_version = 3.7
+python_version = 3.8
 warn_redundant_casts = True
 
 [mypy-aiven.client.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,12 @@ authors = [
 ]
 description="Aiven.io client library / command-line client"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -66,7 +65,7 @@ version-file = "aiven/client/version.py"
 
 [tool.black]
 line-length = 125
-target-version = ['py37', 'py38', 'py39']  # 'py310' is not yet available on Fedora 34
+target-version = ['py38', 'py39']  # 'py310' is not yet available on Fedora 34
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/tests/test_argx.py
+++ b/tests/test_argx.py
@@ -2,12 +2,8 @@
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
-try:
-    from functools import cached_property  # type: ignore
-except ImportError:
-    cached_property = None
-
 from aiven.client.argx import arg, CommandLineTool
+from functools import cached_property
 from typing import Callable, List, NoReturn
 
 


### PR DESCRIPTION
# About this change: What it does, why it matters

Python 3.7 recently reached its end-of-life:
https://devguide.python.org/versions/#versions
