### PR TITLE
Add pypy-3.10 to GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10']
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
# About this change: What it does, why it matters

pypy has a version for Python 3.10, let's use it.


