### PR TITLE
Add --parent-id to project create [EH-573]

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4209,7 +4209,13 @@ ssl.truststore.type=JKS
         self.print_response(projects, json=getattr(self.args, "json", False), table_layout=layout)
 
     @arg("project_name", help="Project name")
-    @arg("--account-id", help="Account ID of the project")
+    @arg(
+        "--account-id",
+        help="Account ID of the project",
+        action=argx.NextReleaseDeprecationNotice,
+        deprecation_message_hint="Please use `--parent-id` instead, which will be mandatory in the next release.",
+        deprecation_help_hint="Will be replaced by `--parent-id` in the next release.",
+    )
     @arg("--billing-group-id", help="Billing group ID of the project")
     @arg.card_id
     @arg.cloud
@@ -4241,11 +4247,17 @@ ssl.truststore.type=JKS
     @arg.vat_id
     @arg.billing_email
     @arg.tech_email
+    @arg.parent_id
     def project__create(self) -> None:
         """Create a project"""
+
+        if self.args.parent_id is not None and self.args.account_id is not None:
+            raise argx.UserError("`--parent-id` and `--account-id` cannot be specified together.")
+
         try:
             project = self.client.create_project(
                 account_id=self.args.account_id,
+                parent_id=self.args.parent_id,
                 billing_address=self.args.billing_address,
                 billing_currency=self.args.billing_currency,
                 billing_extra_text=self.args.billing_extra_text,

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -136,6 +136,7 @@ arg.min_insync_replicas = arg(
 )
 arg.organization_id = arg("--organization-id", required=True, help="Organization identifier")
 arg.organization_id_positional = arg("organization_id", help="Organization identifier")
+arg.parent_id = arg("--parent-id", help="Organization or account identifier")
 arg.partitions = arg("--partitions", type=int, required=True, help="Number of partitions")
 arg.project = arg(
     "--project",

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1608,6 +1608,7 @@ class AivenClient(AivenClientBase):
         self,
         project: str,
         account_id: str | None = None,
+        parent_id: str | None = None,
         billing_group_id: str | None = None,
         card_id: str | None = None,
         cloud: str | None = None,
@@ -1626,6 +1627,8 @@ class AivenClient(AivenClientBase):
             "cloud": cloud,
             "project": project,
         }
+        if parent_id is not None:
+            body["parent_id"] = parent_id
         if account_id is not None:
             body["account_id"] = account_id
         if billing_group_id is not None:


### PR DESCRIPTION
- `--parent-id` option added to the project create.
- `--account-id` option is marked as deprecated with deprecation
warning on project create.

[EH-573]


[EH-573]: https://aiven.atlassian.net/browse/EH-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ