### PR TITLE
Fix typing for use_source_project_billing_group argument

### DIFF
--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1620,7 +1620,7 @@ class AivenClient(AivenClientBase):
         vat_id: str | None = None,
         billing_emails: Sequence[str] | None = None,
         tech_emails: Sequence[str] | None = None,
-        use_source_project_billing_group: str | None = None,
+        use_source_project_billing_group: bool | None = None,
     ) -> Mapping:
         body: dict[str, Any] = {
             "card_id": card_id,


### PR DESCRIPTION
# About this change: What it does, why it matters

Change the type annotation for `client.create_project`.

According to [API specification](https://api.aiven.io/doc/#tag/Project/operation/ProjectCreate), `use_source_project_billing_group` argument is `bool`, not `str`.

