### PR TITLE
Support setting Kafka topic retention in milliseconds

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2878,6 +2878,7 @@ ssl.truststore.type=JKS
     @arg.replication
     @arg.min_insync_replicas
     @arg.retention
+    @arg.retention_ms
     @arg.retention_bytes
     @arg.tag
     @arg(
@@ -2904,6 +2905,7 @@ ssl.truststore.type=JKS
             min_insync_replicas=self.args.min_insync_replicas,
             retention_bytes=self.args.retention_bytes,
             retention_hours=self.args.retention,
+            retention_ms=self.args.retention_ms,
             cleanup_policy=self.args.cleanup_policy,
             tags=tags,
         )
@@ -2915,6 +2917,7 @@ ssl.truststore.type=JKS
     @arg.partitions
     @arg.min_insync_replicas
     @arg.retention
+    @arg.retention_ms
     @arg.retention_bytes
     @arg.tagupdate
     @arg.untag
@@ -2948,6 +2951,7 @@ ssl.truststore.type=JKS
             replication=self.args.replication,
             retention_bytes=self.args.retention_bytes,
             retention_hours=self.args.retention,
+            retention_ms=self.args.retention_ms,
             tags=tags,
         )
         print(response["message"])

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -144,7 +144,10 @@ arg.project = arg(
     default=os.environ.get("AIVEN_PROJECT"),
 )
 arg.replication = arg("--replication", type=int, required=True, help="Replication factor")
-arg.retention = arg("--retention", type=int, help="Retention period in hours (default: unlimited)")
+arg.retention = arg(
+    "--retention", type=int, help="Retention period in hours, superseded by --retention-ms (default: unlimited)"
+)
+arg.retention_ms = arg("--retention-ms", type=int, help="Retention period in milliseconds (default: unlimited)")
 arg.retention_bytes = arg("--retention-bytes", type=int, help="Retention limit in bytes (default: unlimited)")
 arg.tag = arg(
     "--tag", dest="topic_option_tag", metavar="KEY[=VALUE]", action="append", help="Tag to add into topic metadata"

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -605,6 +605,7 @@ class AivenClient(AivenClientBase):
         min_insync_replicas: int,
         retention_bytes: int,
         retention_hours: int,
+        retention_ms: int | None,
         cleanup_policy: str,
         tags: Sequence[Tag] | None = None,
     ) -> Mapping:
@@ -617,6 +618,12 @@ class AivenClient(AivenClientBase):
             "retention_bytes": retention_bytes,
             "retention_hours": retention_hours,
         }
+        config = {}
+        if retention_ms is not None:
+            config["retention_ms"] = retention_ms
+        if config:
+            body["config"] = config
+
         if tags is not None:
             body.update({"tags": tags})
         return self.verify(
@@ -633,6 +640,7 @@ class AivenClient(AivenClientBase):
         partitions: int,
         retention_bytes: int,
         retention_hours: int,
+        retention_ms: int | None,
         min_insync_replicas: int,
         replication: int | None = None,
         tags: Sequence[str] | None = None,
@@ -644,6 +652,12 @@ class AivenClient(AivenClientBase):
             "retention_bytes": retention_bytes,
             "retention_hours": retention_hours,
         }
+        config = {}
+        if retention_ms is not None:
+            config["retention_ms"] = retention_ms
+        if config:
+            body["config"] = config
+
         if tags is not None:
             body.update({"tags": tags})
         return self.verify(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,23 @@ def test_service_user_create() -> None:
                 "tags": [],
             },
         ),
+        (
+            (
+                "service topic-create --project project1 --partitions 1 --replication 2 "
+                + "--retention 1 --retention-ms 123 service1 topic1"
+            ),
+            {
+                "topic_name": "topic1",
+                "cleanup_policy": "delete",
+                "partitions": 1,
+                "replication": 2,
+                "min_insync_replicas": None,
+                "retention_bytes": None,
+                "retention_hours": 1,
+                "config": {"retention_ms": 123},
+                "tags": [],
+            },
+        ),
     ],
 )
 def test_service_topic_create(command_line: str, expected_post_data: Mapping[str, str | int | None]) -> None:
@@ -142,6 +159,17 @@ def test_service_topic_create(command_line: str, expected_post_data: Mapping[str
                 "retention_bytes": None,
                 "retention_hours": None,
                 "tags": [{"key": "key3", "value": "az,.0-9_"}, {"key": "key234", "value": "foo"}],
+            },
+        ),
+        (
+            ("service topic-update --project project1 --partitions 1 --retention 1 --retention-ms 123 service1 topic1"),
+            {
+                "partitions": 1,
+                "replication": None,
+                "min_insync_replicas": None,
+                "retention_bytes": None,
+                "retention_hours": 1,
+                "config": {"retention_ms": 123},
             },
         ),
     ],


### PR DESCRIPTION
The client doesn't resolve the priorities if both `--replication` and `--retention-ms` are provided, the API does (in favor of the latter).
