### PR TITLE
Fix API client compliance with HTTP/1.1

### DIFF
--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -175,7 +175,7 @@ class AivenClientBase:
                 time.sleep(0.2)
 
         # Check API is actually returning data or not
-        if response.status_code == HTTPStatus.NO_CONTENT or response.headers.get("Content-Length", "0") == "0":
+        if response.status_code == HTTPStatus.NO_CONTENT or len(response.content) == 0:
             return {}
 
         result = response.json()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,7 +157,7 @@ def test_service_user_create() -> None:
 def test_service_topic_create(command_line: str, expected_post_data: Mapping[str, str | int | None]) -> None:
     client = AivenClient("")
     session = MagicMock(spec=Session)
-    session.post.return_value = MagicMock(status_code=200, json=MagicMock(return_value={}))
+    session.post.return_value = MagicMock(status_code=200, json=MagicMock(return_value={}), content=b"{}", reason="OK")
     client.session = session
     cli = build_aiven_cli(client)
     assert cli.run(args=command_line.split(" ")) is None
@@ -258,7 +258,9 @@ def test_service_topic_update(command_line: str, expected_put_data: Mapping[str,
 
     client = TestAivenClient()
     session = MagicMock(spec=Session)
-    session.put.return_value = MagicMock(status_code=200, json=MagicMock(return_value={"message": "updated"}))
+    session.put.return_value = MagicMock(
+        status_code=200, json=MagicMock(return_value={"message": "updated"}), content=b'{"message":"updated"}', reason="OK"
+    )
     client.session = session
     cli = build_aiven_cli(client)
     assert cli.run(args=command_line.split(" ")) is None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from http import HTTPStatus
 from typing import Any
 from unittest import mock
 
+import json
 import pytest
 
 
@@ -16,6 +17,10 @@ class MockResponse:
     def __init__(self, status_code: int, json_data: dict[str, Any] | None = None, headers: dict[str, str] | None = None):
         self.status_code = status_code
         self.json_data = json_data
+        if json_data is not None:
+            self.content = json.dumps(json_data).encode("utf-8")
+        else:
+            self.content = b""
         self.headers = {} if headers is None else headers
 
     def json(self) -> Any:
@@ -26,7 +31,7 @@ class MockResponse:
     "response",
     [
         MockResponse(status_code=HTTPStatus.NO_CONTENT),
-        MockResponse(status_code=HTTPStatus.CREATED, headers={"Content-Length": "0"}),
+        MockResponse(status_code=HTTPStatus.CREATED),
     ],
 )
 def test_no_content_returned_from_api(response: MockResponse) -> None:


### PR DESCRIPTION
# About this change: What it does, why it matters

In HTTP/1.1 Content-Length is not always required to be sent by the server - if chunked transfer encoding is used, the Content-Length header can be omitted, and instead length indicated as part of each chunk. Chunked transfer encoding is [always acceptable in HTTP/1.1][1] so by effectively requiring a Content-Length header we are breaking compliance with the spec.

We have avoided this biting us, purely by accident so far due to the web server used for our API, but it will cause problems in the future. Basically, we shouldn't try and figure out the content length by parsing headers in our code, but instead rely on the Requests library which has logic to calculate the correct value based on the HTTP spec.

[1]: https://datatracker.ietf.org/doc/html/rfc9112#section-7.4-2