### PR TITLE
Initial commands on the sustainability APIs

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5807,6 +5807,24 @@ server_encryption_options:
 
         self.print_response(records, json=self.args.json, table_layout=layout)
 
+    @arg.project
+    @arg.json
+    @arg("--since", help="Period begin datestamp in format YYYYMMDD", required=True)
+    @arg("--until", help="Period begin datestamp in format YYYYMMDD", required=True)
+    def sustainability__project_emissions_estimate(self) -> None:
+        """Estimate emissions for a project"""
+        project = self.get_project()
+        since = self.args.since
+        until = self.args.until
+
+        estimate = self.client.sustainability_project_emissions_estimate(project=project, since=since, until=until)
+
+        records = [{"measurement": k, "value": v} for k, v in estimate["emissions"].items()]
+
+        layout = ["measurement", "value"]
+
+        self.print_response(records, json=self.args.json, table_layout=layout)
+
 
 if __name__ == "__main__":
     AivenCLI().main()

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5786,6 +5786,27 @@ server_encryption_options:
         self.client.delete_organization_card(self.args.organization_id, self.args.card_id)
         print("Deleted")
 
+    @arg.project
+    @arg.cloud
+    @arg.json
+    @arg.service_type
+    @arg("-p", "--plan", help="subscription plan of service")
+    def sustainability__service_plan_emissions_project(self) -> None:
+        """Estimate emissions for a service plan"""
+        project = self.get_project()
+        service_type = self._get_service_type()
+        plan = self._get_plan()
+        cloud = self.args.cloud
+
+        estimate = self.client.sustainability_service_plan_emissions_project(
+            project=project, service_type=service_type, plan=plan, cloud=cloud
+        )
+        records = [{"measurement": k, "value": v} for k, v in estimate["emissions"].items()]
+
+        layout = ["measurement", "value"]
+
+        self.print_response(records, json=self.args.json, table_layout=layout)
+
 
 if __name__ == "__main__":
     AivenCLI().main()

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2586,7 +2586,9 @@ class AivenClient(AivenClientBase):
         organization = self.verify(self.get, self.build_path("organization", organization_id))
         self.verify(self.delete, self.build_path("account", organization["account_id"], "payment_method", card_id))
 
-    def sustainability_service_plan_emissions_project(self, project: str, service_type: str, plan: str, cloud: str) -> dict[str, Any]:
+    def sustainability_service_plan_emissions_project(
+        self, project: str, service_type: str, plan: str, cloud: str
+    ) -> dict[str, Any]:
         return self.verify(
             self.get,
             self.build_path(
@@ -2601,4 +2603,17 @@ class AivenClient(AivenClientBase):
                 "clouds",
                 cloud,
             ),
+        )
+
+    def sustainability_project_emissions_estimate(self, project: str, since: str, until: str) -> dict[str, Any]:
+        params = {"since": since, "until": until}
+        return self.verify(
+            self.get,
+            self.build_path(
+                "project",
+                project,
+                "sustainability",
+                "emissions",
+            ),
+            params=params,
         )

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2585,3 +2585,20 @@ class AivenClient(AivenClientBase):
     def delete_organization_card(self, organization_id: str, card_id: str) -> None:
         organization = self.verify(self.get, self.build_path("organization", organization_id))
         self.verify(self.delete, self.build_path("account", organization["account_id"], "payment_method", card_id))
+
+    def sustainability_service_plan_emissions_project(self, project: str, service_type: str, plan: str, cloud: str) -> dict[str, Any]:
+        return self.verify(
+            self.get,
+            self.build_path(
+                "project",
+                project,
+                "sustainability",
+                "emissions-project",
+                "service-types",
+                service_type,
+                "plans",
+                plan,
+                "clouds",
+                cloud,
+            ),
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1679,3 +1679,22 @@ def test_custom_files_update(capsys: CaptureFixture[str]) -> None:
     aiven_client.custom_file_update.assert_called_once()
     captured = capsys.readouterr()
     assert json.loads(captured.out.strip()) == return_value
+
+
+def test_sustainability__service_plan_emissions_project() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.sustainability_service_plan_emissions_project.return_value = {
+        "emissions": {"co2eq_mtons": "0.25", "energy_kwh": "639.50"}
+    }
+    args = [
+        "sustainability",
+        "service-plan-emissions-project",
+        "--project=myproj",
+        "--service-type=kafka",
+        "--plan=business-32",
+        "--cloud=google-europe-west1",
+    ]
+    build_aiven_cli(aiven_client).run(args=args)
+    aiven_client.sustainability_service_plan_emissions_project.assert_called_with(
+        project="myproj", service_type="kafka", plan="business-32", cloud="google-europe-west1"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1698,3 +1698,23 @@ def test_sustainability__service_plan_emissions_project() -> None:
     aiven_client.sustainability_service_plan_emissions_project.assert_called_with(
         project="myproj", service_type="kafka", plan="business-32", cloud="google-europe-west1"
     )
+
+
+def test_sustainability__project_emissions_estimate() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.sustainability_project_emissions_estimate.return_value = {
+        "emissions": {"co2eq_mtons": "0.50", "energy_kwh": "1279.00"}
+    }
+    args = [
+        "sustainability",
+        "project-emissions-estimate",
+        "--project=myproj",
+        "--since=20230901",
+        "--until=20231001",
+    ]
+    build_aiven_cli(aiven_client).run(args=args)
+    aiven_client.sustainability_project_emissions_estimate.assert_called_with(
+        project="myproj",
+        since="20230901",
+        until="20231001",
+    )


### PR DESCRIPTION
Add two new commands to assess carbon impact of Aiven services. The two commands are:
1. Command to project or predict typical emissions for a given service type, plan and cloud selection, and
2. Command to assess project actual emissions over a time period

The backend reporting functionality is still considered experimental, and we're working to ensure validation on the returned numbers.
