### PR TITLE
Remove avn account authentication-method

### DIFF
--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -87,7 +87,6 @@ def user_config_json() -> Callable[[Callable[[CommandLineTool], T]], Callable[[C
 
 
 arg.account_id = arg("account_id", help="Account identifier")
-arg.authentication_id = arg("authentication_id", help="Account authentication method identifier")
 arg.billing_address = arg("--billing-address", help="Physical billing address for invoices")
 arg.billing_currency = arg("--billing-currency", help="Currency for charges")
 arg.billing_extra_text = arg(

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1618,42 +1618,6 @@ class AivenClient(AivenClientBase):
     def get_accounts(self) -> Mapping:
         return self.verify(self.get, "/account", result_key="accounts")
 
-    def create_account_authentication_method(
-        self, account_id: str, method_name: str, method_type: str, options: Mapping[str, str] | None = None
-    ) -> dict:
-        body = dict(options) if options else {}
-        body["authentication_method_name"] = method_name
-        body["authentication_method_type"] = method_type
-        path = self.build_path("account", account_id, "authentication")
-        return self.verify(self.post, path, body=body, result_key="authentication_method")
-
-    def delete_account_authentication_method(self, account_id: str, authentication_id: str) -> Mapping:
-        return self.verify(
-            self.delete,
-            self.build_path("account", account_id, "authentication", authentication_id),
-        )
-
-    def update_account_authentication_method(
-        self,
-        account_id: str,
-        authentication_id: str,
-        method_name: str | None = None,
-        method_enable: bool | None = None,
-        options: Mapping[str, str] | None = None,
-    ) -> Mapping:
-        body: dict[str, Any] = dict(options) if options else {}
-        if method_name is not None:
-            body["authentication_method_name"] = method_name
-        if method_enable is not None:
-            body["authentication_method_enabled"] = method_enable
-
-        path = self.build_path("account", account_id, "authentication", authentication_id)
-        return self.verify(self.put, path, body=body, result_key="authentication_method")
-
-    def get_account_authentication_methods(self, account_id: str) -> Sequence[dict[str, Any]]:
-        path = self.build_path("account", account_id, "authentication")
-        return self.verify(self.get, path, result_key="authentication_methods")
-
     def create_project(
         self,
         project: str,


### PR DESCRIPTION
# About this change: What it does, why it matters

We want to keep the user experience for authentication-methods in the console.
Therefore we should remove the functionality from the cli.

[EH-829]




[EH-829]: https://aiven.atlassian.net/browse/EH-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ