### PR TITLE
fix hatchling building an empty distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ source = "vcs"
 [tool.hatch.build.hooks.vcs]
 version-file = "aiven/client/version.py"
 
+[tool.hatch.build.targets.wheel]
+packages = ["aiven"]
+
 [tool.black]
 line-length = 125
 target-version = ['py38', 'py39', 'py310', 'py311']


### PR DESCRIPTION
Building from source/sdist is currently broken with latest `hatchling` (seems like since [1.19.0](https://github.com/pypa/hatch/releases/tag/hatchling-v1.19.0), perhaps worth a bug report there):

```shell
$ python3 -m venv .venv
$ .venv/bin/pip install --no-binary=aiven-client aiven-client
$ .venv/bin/avn --version
Traceback (most recent call last):
  File "/tmp/aiven-client/.venv/bin/avn", line 5, in <module>
    from aiven.client.__main__ import main
ModuleNotFoundError: No module named 'aiven.client.__main__'
$ find .venv/lib/python3.11/site-packages/aiven/
.venv/lib/python3.11/site-packages/aiven/
.venv/lib/python3.11/site-packages/aiven//client
.venv/lib/python3.11/site-packages/aiven//client/version.py
```

So only `version.py` is included, commenting out the `[tool.hatch.build.hooks.vcs]` table gives a better error message:

```shell
$ .venv/bin/pip install .
...
ValueError: Unable to determine which files to ship inside the wheel using the following heuristics: https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see: https://hatch.pypa.io/latest/config/build/

As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:

[tool.hatch.build.targets.wheel]
packages = ["src/foo"]
```
