### PR TITLE
Fix README.rst syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,7 +344,7 @@ Delete a service integration::
     $ avn service integration-delete --project <project> <integration_id>
 
 Custom Files
---------------------
+------------
 
 Listing files::
 
@@ -362,6 +362,7 @@ Uploading new files::
 Updating existing files::
 
     $ avn service custom-file update --project <project> --file_path <file_path> --file_id <file_id> <service_name>
+
 .. _teams:
 
 Working with Teams


### PR DESCRIPTION
GH action to publish a new release to PyPi failed with:

ERROR    `long_description` has syntax errors in markup and would not be
         rendered on PyPI.
         line 365: Warning: Literal block ends without a blank line; unexpected
         unindent.

Add the empty line at the end of the literal block.

Also adjust the length of the underlining for the title above, it does not seem to count as a syntax error, but is consistent with the rest of the README.

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)


