### PR TITLE
feature: Expose retry paramater for update_service_topic

### DIFF
--- a/aiven/client/_typing.py
+++ b/aiven/client/_typing.py
@@ -1,0 +1,10 @@
+from typing import NoReturn
+
+
+def assert_never(arg: NoReturn, /) -> NoReturn:
+    """
+    Backport of standard library typing.assert_never.
+
+    https://docs.python.org/3/library/typing.html#typing.assert_never
+    """
+    raise AssertionError("Expected code to be unreachable")


### PR DESCRIPTION
# About this change: What it does, why it matters

To allow controlling retry behavior, this commit adds the ability to pass in a `RetrySpec` when instantiating `AivenClient`. This maintains existing behavior for all current instantiations, but when configured this overrides these properties of all calls made through the client:

- Passing `RetrySpec(http_methods=("GET", "PUT"))` will make the client use retries for PUT in addition to the default GET.
- Passing `RetrySpec(sleep=timedelta(seconds=1))` changes sleep time in between retries to 1 second for GET calls, other methods will have no retries.
- Passing `RetrySpec(attempts=5)` changes the number of attempts for GET calls, other methods will have no retries.
- Passing `RetrySpec(attempts=5, sleep=timedelta(seconds=1), http_methods=("GET", "PUT"))` will set the configured values for GET and PUT operations, all other methods will have no retries.

In short, while maintaining existing behavior, this commit introduces ability to configure which methods should use retries, and it allows configuring how many and the sleep time in between.