### PR TITLE
client: allow to provision Google BYOC [MILK-135]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - id: dependencies
-        run: |
-          pip install -e .[dev]
+        run: make install-py
 
       - id: validate-style
         run: make validate-style

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ release = 1
 PYTHON ?= python3
 PYTHON_DIRS = aiven tests
 
+all: install-py validate-style lint test
+
+install-py:
+	$(PYTHON) -m pip install -e .[dev]
+
 test: pytest
+
 lint: ruff flake8 mypy
 
 reformat:

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5938,7 +5938,7 @@ server_encryption_options:
     @arg("--aws-iam-role-arn", help="The IAM role that Aiven is authorized to assume to operate the cloud (AWS)")
     @arg(
         "--google-privilege-bearing-service-account-id",
-        help="The privilege-bearing service account that Aiven is authorized to impersonate to operate the cloud (AWS)",
+        help="The privilege-bearing service account that Aiven is authorized to impersonate to operate the cloud (Google)",
     )
     def byoc__provision(self) -> None:
         """Provision resources for a Bring Your Own Cloud cloud."""

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5942,6 +5942,10 @@ server_encryption_options:
     )
     def byoc__provision(self) -> None:
         """Provision resources for a Bring Your Own Cloud cloud."""
+        if self.args.aws_iam_role_arn and self.args.google_privilege_bearing_service_account_id:
+            raise argx.UserError(
+                "--aws-iam-role-arn and --google-privilege-bearing-service-account-id are mutually exclusive."
+            )
         output = self.client.byoc_provision(
             organization_id=self.args.organization_id,
             byoc_id=self.args.byoc_id,

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5936,10 +5936,17 @@ server_encryption_options:
     @arg("--organization-id", required=True, help="Identifier of the organization of the custom cloud environment")
     @arg("--byoc-id", required=True, help="Identifier of the custom cloud environment that defines the BYOC cloud")
     @arg("--aws-iam-role-arn", help="The IAM role that Aiven is authorized to assume to operate the cloud (AWS)")
+    @arg(
+        "--google-privilege-bearing-service-account-id",
+        help="The privilege-bearing service account that Aiven is authorized to impersonate to operate the cloud (AWS)",
+    )
     def byoc__provision(self) -> None:
         """Provision resources for a Bring Your Own Cloud cloud."""
         output = self.client.byoc_provision(
-            organization_id=self.args.organization_id, byoc_id=self.args.byoc_id, aws_iam_role_arn=self.args.aws_iam_role_arn
+            organization_id=self.args.organization_id,
+            byoc_id=self.args.byoc_id,
+            aws_iam_role_arn=self.args.aws_iam_role_arn,
+            google_privilege_bearing_service_account_id=self.args.google_privilege_bearing_service_account_id,
         )
         self.print_response(output)
 

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1,4 +1,4 @@
-# Copright 2015, Aiven, https://aiven.io/
+# Copyright 2015, Aiven, https://aiven.io/
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Aiven, https://aiven.io/
+# Copright 2015, Aiven, https://aiven.io/
 #
 # This file is under the Apache License, Version 2.0.
 # See the file `LICENSE` for details.
@@ -2750,9 +2750,18 @@ class AivenClient(AivenClientBase):
     def byoc_list(self, *, organization_id: str) -> Mapping[Any, Any]:
         return self.verify(self.get, self.build_path("organization", organization_id, "custom-cloud-environments"))
 
-    def byoc_provision(self, *, organization_id: str, byoc_id: str, aws_iam_role_arn: str | None) -> Mapping[Any, Any]:
+    def byoc_provision(
+        self,
+        *,
+        organization_id: str,
+        byoc_id: str,
+        aws_iam_role_arn: str | None = None,
+        google_privilege_bearing_service_account_id: str | None = None,
+    ) -> Mapping[Any, Any]:
         if aws_iam_role_arn is not None:
             body = {"aws_iam_role_arn": aws_iam_role_arn}
+        elif google_privilege_bearing_service_account_id is not None:
+            body = {"google_privilege_bearing_service_account_id": google_privilege_bearing_service_account_id}
         else:
             body = {}
         return self.verify(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1835,6 +1835,21 @@ def test_byoc_provision(provider: str, region: str, byoc_account_id: str) -> Non
     )
 
 
+def test_byoc_provision_args() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    args = [
+        "byoc",
+        "provision",
+        "--organization-id=org123456789a",
+        "--byoc-id=d6a490ad-f43d-49d8-b3e5-45bc5dbfb387",
+        "--aws-iam-role-arn=arn:aws:iam::123456789012:role/role-name",
+        "--google-privilege-bearing-service-account-id="
+        "projects/aiven-test-byoa/serviceAccounts/aiven-cce4bafaf95155@aiven-test-byoa.iam.gserviceaccount.com",
+    ]
+    build_aiven_cli(aiven_client).run(args=args)
+    aiven_client.byoc_provision.assert_not_called()
+
+
 def test_byoc_delete() -> None:
     aiven_client = mock.Mock(spec_set=AivenClient)
     aiven_client.byoc_delete.return_value = {"message": "deleting"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1790,12 +1790,23 @@ def test_byoc_update() -> None:
     )
 
 
-def test_byoc_provision() -> None:
+@pytest.mark.parametrize(
+    "provider,region,byoc_account_id",
+    [
+        ("aws", "eu-west-2", "arn:aws:iam::123456789012:role/role-name"),
+        (
+            "google",
+            "europe-north1",
+            "projects/aiven-test-byoa/serviceAccounts/aiven-cce4bafaf95155@aiven-test-byoa.iam.gserviceaccount.com",
+        ),
+    ],
+)
+def test_byoc_provision(provider: str, region: str, byoc_account_id: str) -> None:
     aiven_client = mock.Mock(spec_set=AivenClient)
     aiven_client.byoc_provision.return_value = {
         "custom_cloud_environment": {
-            "cloud_provider": "aws",
-            "cloud_region": "eu-west-2",
+            "cloud_provider": provider,
+            "cloud_region": region,
             "contact_emails": [],
             "custom_cloud_environment_id": "d6a490ad-f43d-49d8-b3e5-45bc5dbfb387",
             "deployment_model": "standard",
@@ -1804,18 +1815,23 @@ def test_byoc_provision() -> None:
             "state": "creating",
         }
     }
+    byoc_account_id_args = {
+        "aws": "--aws-iam-role-arn",
+        "google": "--google-privilege-bearing-service-account-id",
+    }
     args = [
         "byoc",
         "provision",
         "--organization-id=org123456789a",
         "--byoc-id=d6a490ad-f43d-49d8-b3e5-45bc5dbfb387",
-        "--aws-iam-role-arn=arn:aws:iam::123456789012:role/role-name",
+        f"{byoc_account_id_args[provider]}={byoc_account_id}",
     ]
     build_aiven_cli(aiven_client).run(args=args)
     aiven_client.byoc_provision.assert_called_once_with(
         organization_id="org123456789a",
         byoc_id="d6a490ad-f43d-49d8-b3e5-45bc5dbfb387",
-        aws_iam_role_arn="arn:aws:iam::123456789012:role/role-name",
+        aws_iam_role_arn=byoc_account_id if provider == "aws" else None,
+        google_privilege_bearing_service_account_id=byoc_account_id if provider == "google" else None,
     )
 
 


### PR DESCRIPTION
In order to provision a Google BYOC we need to pass the customer's privilege-bearing service account ID, so we can later impersonate it and start service node instances in the Google account of the customer.

Also, ease local testing:
- replace 'pip install -e .[dev]' by 'make install-py'
- create a default 'make' target to locally run: install-py, validate-style, lint and test

[MILK-135]

[MILK-135]: https://aiven.atlassian.net/browse/MILK-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ