### PR TITLE
Fix help string for cluster option in Apache Kafka native ACLs

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -6210,7 +6210,7 @@ server_encryption_options:
         "--cluster",
         action="store_const",
         const="kafka-cluster",
-        help="Group resource type to which ACL should be added",
+        help="The ACL is applied to the cluster resource",
     )
     @arg(
         "--transactional-id",


### PR DESCRIPTION
Fix the help string for `--cluster` option of `avn service kafka-service-add`.


