### PR TITLE
client: allow 'privatelink refresh' for AWS [MILK-425]

### DIFF
--- a/aiven/client/argx.py
+++ b/aiven/client/argx.py
@@ -23,7 +23,7 @@ import sys
 
 # Optional shell completions
 try:
-    import argcomplete  # type: ignore
+    import argcomplete  # type: ignore[import-not-found]
 
     ARGCOMPLETE_INSTALLED = True
 except ImportError:

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1006,6 +1006,15 @@ class AivenCLI(argx.CommandLineTool):
 
     @arg.project
     @arg.service_name
+    def service__privatelink__aws__refresh(self) -> None:
+        """Refresh AWS PrivateLink to discover new endpoints"""
+        self.client.refresh_service_privatelink_aws(
+            project=self.get_project(),
+            service=self.args.service_name,
+        )
+
+    @arg.project
+    @arg.service_name
     @arg("--format", help="Format string for output")
     @arg.json
     def service__privatelink__aws__connection__list(self) -> None:

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1492,6 +1492,10 @@ class AivenClient(AivenClientBase):
         path = self._privatelink_path(project, service, "aws")
         return self.verify(self.get, path)
 
+    def refresh_service_privatelink_aws(self, project: str, service: str) -> Mapping:
+        path = self._privatelink_path(project, service, "aws", "refresh")
+        return self.verify(self.post, path)
+
     def list_service_privatelink_aws_connections(self, project: str, service: str) -> Sequence[dict[str, Any]]:
         path = self._privatelink_path(project, service, "aws") + "/connections"
         return self.verify(self.get, path, result_key="connections")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2122,3 +2122,20 @@ def test_service__kafka_acl_delete() -> None:
         service="kafka-1",
         acl_id="acl4f549bfee6a",
     )
+
+
+def test_service__privatelink__aws__refresh() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.refresh_service_privatelink_aws.return_value = {"message": "refreshed"}
+    args = [
+        "service",
+        "privatelink",
+        "aws",
+        "refresh",
+        "kafka-2921638b",
+    ]
+    build_aiven_cli(aiven_client).run(args=args)
+    aiven_client.refresh_service_privatelink_aws.assert_called_once_with(
+        project="new-project-name",
+        service="kafka-2921638b",
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -326,3 +326,28 @@ def test_byoc_tags_replace() -> None:
                 '"byoc_resource_tag:key_3": "byoc_resource_tag:keep-the-whole-value-3"}}'
             ),
         )
+
+
+def test_refresh_service_privatelink_aws() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "post") as post_mock:
+        post_mock.return_value = MockResponse(
+            status_code=HTTPStatus.OK,
+            headers={"Content-Type": "application/json"},
+            json_data={"message": "refreshed"},
+        )
+
+        response = aiven_client.refresh_service_privatelink_aws(
+            project="new-project-name",
+            service="kafka-2921638b",
+        )
+
+        assert response == {"message": "refreshed"}
+
+        post_mock.assert_called_once_with(
+            "test_base_url/v1/project/new-project-name/service/kafka-2921638b/privatelink/aws/refresh",
+            headers={"content-type": "application/octet-stream"},
+            params=None,
+            data=None,
+        )


### PR DESCRIPTION
We're adding `avn service privatelink aws refresh <service>`.

The command `privatelink refresh` already exists for Azure and Google, because these cloud providers don't have a notification system like AWS SQS queue. AWS SQS queue events are used to notify Aiven when a privatelink is changed. We use these events to refresh the corresponding privatelink object.

Explicitly exposing the `refresh` command for AWS will allow two things:
* support PrivateLink for AWS BYOC without AWS SQS queues to start with. AWS SQS queues for BYOC can be implemented later,
* support the manual refresh of PrivateLink connections in case the SQS queue system (used for PrivateLink in Project VPC) is down.

[MILK-425]

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)




[MILK-425]: https://aiven.atlassian.net/browse/MILK-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ