### PR TITLE
Update actions/setup-python@v1 Python version

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.12
 
     - name: Install pypa/build
       run: >-


### PR DESCRIPTION
3.8 is no longer supported.

# About this change: What it does, why it matters

(all contributors please complete this section, including maintainers)


