### PR TITLE
Fix a typo in service__task_get help text

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2828,7 +2828,7 @@ ssl.truststore.type=JKS
     @arg("--format", help="Format string for output")
     @arg.json
     def service__task_get(self) -> None:
-        """Create a service task"""
+        """Get a service task"""
         response = self.client.get_service_task(
             project=self.get_project(),
             service=self.args.service_name,


### PR DESCRIPTION
# About this change: What it does, why it matters

Copy-paste typo gets displayed by `avn service --help`.

