### PR TITLE
feat: add inkless.enable config to topic creation

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2866,6 +2866,8 @@ ssl.truststore.type=JKS
     @arg.remote_storage_disable
     @arg.local_retention_ms
     @arg.local_retention_bytes
+    @arg.inkless_enable
+    @arg.inkless_disable
     @arg.tag
     @arg(
         "--cleanup-policy",
@@ -2896,6 +2898,7 @@ ssl.truststore.type=JKS
             remote_storage_enable=self._remote_storage_enable(),
             local_retention_ms=self.args.local_retention_ms,
             local_retention_bytes=self.args.local_retention_bytes,
+            inkless_enable=self._inkless_enable(),
             tags=tags,
         )
         print(response)
@@ -2958,6 +2961,16 @@ ssl.truststore.type=JKS
         if self.args.remote_storage_enable:
             return True
         elif self.args.remote_storage_disable:
+            return False
+        else:
+            return None
+
+    def _inkless_enable(self) -> bool | None:
+        if self.args.inkless_enable and self.args.inkless_disable:
+            raise argx.UserError("Only set at most one of --inkless-enable and --inkless-disable")
+        if self.args.inkless_enable:
+            return True
+        elif self.args.inkless_disable:
             return False
         else:
             return None

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -161,6 +161,8 @@ arg.local_retention_bytes = arg(
     type=int,
     help="Local retention limit in bytes in case of tiered storage (default: equals to total retention.bytes)",
 )
+arg.inkless_enable = arg("--inkless-enable", help="Enable inkless", action="store_true")
+arg.inkless_disable = arg("--inkless-disable", help="Disable inkless", action="store_true")
 arg.tag = arg(
     "--tag", dest="topic_option_tag", metavar="KEY[=VALUE]", action="append", help="Tag to add into topic metadata"
 )

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -711,6 +711,7 @@ class AivenClient(AivenClientBase):
         remote_storage_enable: bool | None = None,
         local_retention_ms: int | None = None,
         local_retention_bytes: int | None = None,
+        inkless_enable: bool | None = None,
         tags: Sequence[Tag] | None = None,
     ) -> Mapping:
         body: dict[str, Any] = {
@@ -731,6 +732,8 @@ class AivenClient(AivenClientBase):
             config["local_retention_ms"] = local_retention_ms
         if local_retention_bytes is not None:
             config["local_retention_bytes"] = local_retention_bytes
+        if inkless_enable is not None:
+            config["inkless_enable"] = inkless_enable
         if config:
             body["config"] = config
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,44 @@ def test_service_user_create() -> None:
                 "tags": [],
             },
         ),
+        (
+            (
+                "service topic-create --project project1 --partitions 1 --replication 1 "
+                + "--inkless-enable service1 topic1"
+            ),
+            {
+                "topic_name": "topic1",
+                "cleanup_policy": "delete",
+                "partitions": 1,
+                "replication": 1,
+                "min_insync_replicas": None,
+                "retention_bytes": None,
+                "retention_hours": None,
+                "config": {
+                    "inkless_enable": True,
+                },
+                "tags": [],
+            },
+        ),
+        (
+            (
+                "service topic-create --project project1 --partitions 1 --replication 1 "
+                + "--inkless-disable service1 topic1"
+            ),
+            {
+                "topic_name": "topic1",
+                "cleanup_policy": "delete",
+                "partitions": 1,
+                "replication": 1,
+                "min_insync_replicas": None,
+                "retention_bytes": None,
+                "retention_hours": None,
+                "config": {
+                    "inkless_enable": False,
+                },
+                "tags": [],
+            },
+        ),
     ],
 )
 def test_service_topic_create(command_line: str, expected_post_data: Mapping[str, str | int | None]) -> None:


### PR DESCRIPTION
Inkless topics can be enabled only on creation.
Adding the config flags to support this.



