### PR TITLE
Add command to show info for an application user's token

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5082,6 +5082,43 @@ server_encryption_options:
         self.print_response(tokens, json=self.args.json, table_layout=layout)
 
     @arg.json
+    @arg.organization_id
+    @arg("--verbose", action="store_true", default=False, help="Show more details")
+    @arg("user_id", help="Application User ID")
+    @arg("token_prefix", help="Token prefix to get info for")
+    def application_user__token__info(self) -> None:
+        """Show info on the specified token for an application user."""
+        tokens = self.client.list_application_user_tokens(
+            organization_id=self.args.organization_id,
+            user_id=self.args.user_id,
+        )
+        token = next((token for token in tokens if token["token_prefix"] == self.args.token_prefix), None)
+        if not token:
+            raise argx.UserError(f"Token with prefix '{self.args.token_prefix}' not found for user {self.args.user_id}")
+
+        layout = [
+            "token_prefix",
+            "description",
+            "last_used_time",
+            "expiry_time",
+            "currently_active",
+        ]
+        if self.args.verbose:
+            layout.extend(
+                [
+                    "create_time",
+                    "created_manually",
+                    "extend_when_used",
+                    "ip_allowlist",
+                    "last_ip",
+                    "last_user_agent_human_readable",
+                    "max_age_seconds",
+                    "scopes",
+                ]
+            )
+        self.print_response(token, json=self.args.json, table_layout=layout, single_item=True)
+
+    @arg.json
     @arg.force
     @arg.organization_id
     @arg("user_id", help="Application User ID")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2699,6 +2699,74 @@ def test_application_user_token_list() -> None:
     )
 
 
+def test_application_user_token_info() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.list_application_user_tokens.return_value = [
+        {
+            "token_prefix": "token-prefix",
+            "create_time": "2023-10-01T12:00:00Z",
+            "created_manually": True,
+            "currently_active": True,
+            "description": "token-description",
+            "expiry_time": "2024-10-01T12:00:00Z",
+            "extend_when_used": False,
+            "ip_allowlist": ["192.168.0.0/24"],
+            "last_ip": "127.0.0.1",
+            "last_used_time": "2023-10-01T12:30:00Z",
+            "last_user_agent_human_readable": "Mozilla/5.0",
+            "max_age_seconds": 3600,
+            "scopes": ["read", "write"],
+        },
+    ]
+    args = [
+        "application-user",
+        "token",
+        "info",
+        "--organization-id=org123456789a",
+        "app-user-id",
+        "token-prefix",
+    ]
+    build_aiven_cli(aiven_client).run(args=args)
+    aiven_client.list_application_user_tokens.assert_called_once_with(
+        organization_id="org123456789a",
+        user_id="app-user-id",
+    )
+
+
+def test_application_user_token_info_not_found() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.list_application_user_tokens.return_value = [
+        {
+            "token_prefix": "token-prefix",
+            "create_time": "2023-10-01T12:00:00Z",
+            "created_manually": True,
+            "currently_active": True,
+            "description": "token-description",
+            "expiry_time": "2024-10-01T12:00:00Z",
+            "extend_when_used": False,
+            "ip_allowlist": ["192.168.0.0/24"],
+            "last_ip": "127.0.0.1",
+            "last_used_time": "2023-10-01T12:30:00Z",
+            "last_user_agent_human_readable": "Mozilla/5.0",
+            "max_age_seconds": 3600,
+            "scopes": ["read", "write"],
+        },
+    ]
+    args = [
+        "application-user",
+        "token",
+        "info",
+        "--organization-id=org123456789a",
+        "app-user-id",
+        "token-not-found",
+    ]
+    assert 1 == build_aiven_cli(aiven_client).run(args=args)
+    aiven_client.list_application_user_tokens.assert_called_once_with(
+        organization_id="org123456789a",
+        user_id="app-user-id",
+    )
+
+
 def test_application_user_token_revoke() -> None:
     aiven_client = mock.Mock(spec_set=AivenClient)
     args = [


### PR DESCRIPTION
It might be useful to retrieve information on a given application-user's access token, given it's token-prefix. This can be used, for example, to check when the token was last used, or its expire date.


