### PR TITLE
docs: add application-users section and fix organization argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,25 +190,48 @@ View project management event log::
 
   $ avn events
 
-.. _services:
+.. _application-users:
+
+Working with Application Users
+------------------------------
+
+List organization application users::
+
+  $ avn application-user list --organization-id <organization_id>
+
+Create a new application user::
+
+  $ avn application-user create --organization-id <organization_id> --name "My Application"
+
+Get information on an application user::
+
+  $ avn application-user info <user_id> --organization-id <organization_id>
+
+Create a token for an application user::
+
+  $ avn application-user token create <user_id> --organization-id <organization_id> --description "Token V1 - 2025-07-15"
+
+.. _permissions:
 
 Working with Permissions
 ------------------------
 
 List organization permissions for a given resource type (one of "organization", "organization_unit", or "project")::
 
-  $ avn permissions list --organization <organization_id> --resource-type <resource_type>
+  $ avn permissions list --organization-id <organization_id> --resource-type <resource_type>
 
 Set permissions for a given principal in the scope of resource type and resource ID::
 
-  $ avn permissions set --organization <organization_id> --resource-type <resource_type> --resource-id <resource_id> --principal-id <principal_id> --principal-type <principal_type> --permission <permission1> --permission <permission2>
+  $ avn permissions set --organization-id <organization_id> --resource-type <resource_type> --resource-id <resource_id> --principal-id <principal_id> --principal-type <principal_type> --permission <permission1> --permission <permission2>
 
 Note that setting permissions will override any existing permissions for the specified resource type and resource ID.
 
 For example the following commands will set the permissions for the project with ID "proj1" to assign role "developer" to the user with ID "user1", and let them to be an "operator" for project "proj2"::
 
-  $ avn permissions set --organization <organization_id> --resource-type project --resource-id proj1 --permission developer --principal-id user1 --principal-type user
-  $ avn permissions set --organization <organization_id> --resource-type project --resource-id proj2 --permission operator --principal-id user1 --principal-type user
+  $ avn permissions set --organization-id <organization_id> --resource-type project --resource-id proj1 --permission developer --principal-id user1 --principal-type user
+  $ avn permissions set --organization-id <organization_id> --resource-type project --resource-id proj2 --permission operator --principal-id user1 --principal-type user
+
+.. _services:
 
 Explore Existing Services
 -------------------------


### PR DESCRIPTION
# About this change: What it does, why it matters

We added the `application-user` commands but didn't include any mention of them in the docs.

