### PR TITLE
client: fix typo in disk space gib argument metavar

### DIFF
--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -116,7 +116,11 @@ arg.config_file = arg(
 )
 arg.country_code = arg("--country-code", help="Billing country code")
 arg.disk_space_mb = arg(
-    "--disk-space-gib", dest="disk_space_mb", type=lambda value: int(value) * 1024, help="Disk space for data storage (GiB)"
+    "--disk-space-gib",
+    metavar="DISK_SPACE_GIB",
+    dest="disk_space_mb",
+    type=lambda value: int(value) * 1024,
+    help="Disk space for data storage (GiB)",
 )
 arg.email = arg("email", help="User email address")
 arg.force = arg(


### PR DESCRIPTION
# About this change: What it does, why it matters

The help test reads `--disk-space-gib DISK_SPACE_MB` in the first
line and lower in the description:

```
  --disk-space-gib DISK_SPACE_MB
                        Disk space for data storage (GiB)
```

The metavar `DISK_SPACE_MB` is inferred from the variable name since we
implicitly convert to MiB by multiplying by 1024 in the code. By
specifying it explicitly we can avoid confusing the user as they'll not
be exposed to the MiB value, neither in the usage of the CLI or in the
error message.

It's only relevant if they are making the API call directly.
