### PR TITLE
remove stale teams section from README and dead cliarg definitions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -412,52 +412,6 @@ Updating existing files::
 
     $ avn service custom-file update --project <project> --file_path <file_path> --file_id <file_id> <service_name>
 
-.. _teams:
-
-Working with Teams
-------------------
-
-List account teams::
-
-  $ avn account team list <account_id>
-
-Create a team::
-
-  $ avn account team create --team-name <team_name> <account_id>
-
-Delete a team::
-
-  $ avn account team delete --team-id <team_id> <account_id>
-
-Attach team to a project::
-
-  $ avn account team project-attach --team-id <team_id> --project <project_name> <account_id> --team-type <admin|developer|operator|read_only>
-
-
-Detach team from project::
-
-  $ avn account team project-detach --team-id <team_id> --project <project_name> <account_id>
-
-List projects associated to the team::
-
-  $ avn account team project-list --team-id <team_id> <account_id>
-
-List members of the team::
-
-  $ avn account team user-list --team-id <team_id> <account_id>
-
-Invite a new member to the team::
-
-  $ avn account team user-invite --team-id <team_id> <account_id> <somebody@example.com>
-
-See the list of pending invitations::
-
-  $ avn account team user-list-pending --team-id <team_id> <account_id>
-
-Remove user from the team::
-
-  $ avn account team user-delete --team-id <team_id> --user-id <user_id> <account_id>
-
 
 .. _oauth2-clients:
 

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -205,8 +205,6 @@ arg.ns_block_data_expiry_dur = arg(
 arg.ns_buffer_future_dur = arg("--ns-buffer-future-dur", help="Namespace block size duration (written like 30m/25h etc)")
 arg.ns_buffer_past_dur = arg("--ns-buffer-past-dur", help="Namespace block size duration (written like 30m/25h etc)")
 arg.ns_writes_to_commitlog = arg("--ns-writes-to-commitlog", help="Namespace writes to commit log")
-arg.team_name = arg("--team-name", help="Team  name", required=True)
-arg.team_id = arg("--team-id", help="Team identifier", required=True)
 arg.timeout = arg("--timeout", type=int, help="Wait for up to N seconds (default: infinite)")
 arg.topic = arg("topic", help="Topic name")
 arg.user_config = arg(


### PR DESCRIPTION
Follow-up to removal of team commands from aiven client 84a81c1
which dropped the `avn account team ...` subcommands and the
corresponding helpers from `client.py` but left the "Working with Teams"
section in `README.rst` behind, pointing users at CLI commands that no
longer exist, and two orphaned argument definitions
(`arg.team_name`, `arg.team_id`) in `cliarg.py` with no remaining call
sites.

The underlying public API endpoints are deprecated, and have all
passed their sunset dates. Teams have been replaced by Aiven
Organizations user-groups and the Permissions API.
