### PR TITLE
remove deprecated `avn credits claim` command and client method

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4859,16 +4859,6 @@ ssl.truststore.type=JKS
         layout = [["code", "remaining_value"]]
         self.print_response(project_credits, json=self.args.json, table_layout=layout)
 
-    @arg.json
-    @arg.project
-    @arg("code", help="Credit code")
-    def credits__claim(self) -> None:
-        """Claim a credit code"""
-        project_name = self.get_project()
-        result = self.client.claim_project_credit(project=project_name, credit_code=self.args.code)
-        if self.args.json:
-            self.print_response(result, json=True)
-
     def _print_billing_groups(self, billing_groups: Sequence[dict[str, Any]]) -> None:
         for billing_group in billing_groups:
             billing_group["credit_card"] = self._format_card_info(billing_group)

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1957,14 +1957,6 @@ class AivenClient(AivenClientBase):
             result_key="credits",
         )
 
-    def claim_project_credit(self, project: str, credit_code: str) -> Mapping:
-        return self.verify(
-            self.post,
-            self.build_path("project", project, "credits"),
-            body={"code": credit_code},
-            result_key="credit",
-        )
-
     def create_billing_group(
         self,
         billing_group_name: str,


### PR DESCRIPTION
The backing endpoint `POST /project/<project>/credits` was sunset on
2026-03-11 and now sending `410 Gone`. Drop the CLI handler and the
`claim_project_credit` client method.
