### PR TITLE
Add support for service upgrade pipeline APIs

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -6875,6 +6875,109 @@ ssl.truststore.type=JKS
         accessors = self.client.list_cmk_accessors(project=project)
         self.print_response(accessors, json=True)
 
+    @arg.json
+    @arg.organization_id
+    @arg("--source-project", help="Project of the source service, if other than the default")
+    @arg("source_service")
+    @arg("--destination-project", help="Project of the destination service, if ofher than the default")
+    @arg("destination_service")
+    @arg("--auto-validation-delay-days", type=int, help="Validate upgrade automatically after this many days")
+    def upgrade_pipeline__step__create(self) -> None:
+        """Create an upgrade pipeline step"""
+        default_project = self.get_project()
+        response = self.client.upgrade_pipeline_step_create(
+            organization_id=self.args.organization_id,
+            source_project_name=self.args.source_project or default_project,
+            source_service_name=self.args.source_service,
+            destination_project_name=self.args.destination_project or default_project,
+            destination_service_name=self.args.destination_service,
+            auto_validation_delay_days=self.args.auto_validation_delay_days,
+        )
+        layout = [
+            "step_id",
+            "source_project_name",
+            "source_service_name",
+            "destination_project_name",
+            "destination_service_name",
+            "auto_validation_delay_days",
+        ]
+        self.print_response([response], json=self.args.json, table_layout=layout)
+
+    @arg.json
+    @arg.organization_id
+    @arg("step_id", help="Upgrade step ID")
+    @arg("--auto-validation-delay-days", type=int, help="Validate upgrade automatically after this many days")
+    def upgrade_pipeline__step__update(self) -> None:
+        """Update an upgrade pipeline step"""
+        response = self.client.upgrade_pipeline_step_update(
+            organization_id=self.args.organization_id,
+            step_id=self.args.step_id,
+            auto_validation_delay_days=self.args.auto_validation_delay_days,
+        )
+        layout = [
+            "step_id",
+            "source_project_name",
+            "source_service_name",
+            "destination_project_name",
+            "destination_service_name",
+            "auto_validation_delay_days",
+        ]
+        self.print_response([response], json=self.args.json, table_layout=layout)
+
+    @arg.json
+    @arg.organization_id
+    @arg("step_id", help="Upgrade step ID")
+    def upgrade_pipeline__step__delete(self) -> None:
+        """Delete an upgrade pipeline step"""
+        response = self.client.upgrade_pipeline_step_delete(
+            organization_id=self.args.organization_id, step_id=self.args.step_id
+        )
+        self.print_response(response, json=self.args.json, table_layout=[])
+
+    @arg.json
+    @arg.organization_id
+    @arg("step_id", help="Upgrade step ID")
+    def upgrade_pipeline__step__get(self) -> None:
+        """Get an upgrade pipeline step"""
+        response = self.client.upgrade_pipeline_step_get(
+            organization_id=self.args.organization_id, step_id=self.args.step_id
+        )
+        layout = [
+            "step_id",
+            "source_project_name",
+            "source_service_name",
+            "destination_project_name",
+            "destination_service_name",
+            "auto_validation_delay_days",
+        ]
+        self.print_response([response], json=self.args.json, table_layout=layout)
+
+    @arg.json
+    @arg.organization_id
+    def upgrade_pipeline__step__list(self) -> None:
+        """List upgrade pipeline steps"""
+        response = self.client.upgrade_pipeline_step_list(organization_id=self.args.organization_id)
+        layout = [
+            "step_id",
+            "source_project_name",
+            "source_service_name",
+            "destination_project_name",
+            "destination_service_name",
+            "auto_validation_delay_days",
+        ]
+        self.print_response(response["steps"], json=self.args.json, table_layout=layout)
+
+    @arg.json
+    @arg.project
+    @arg.service_name
+    @arg("--comment", help="Validate upgrade step with this comment")
+    def upgrade_pipeline__step__validate_for_service(self) -> None:
+        """Validate currently running service version for upgrade pipeline"""
+        project_name = self.get_project()
+        self.client.upgrade_pipeline_step_validate(
+            project_name=project_name, service_name=self.args.service_name, comment=self.args.comment
+        )
+
 
 if __name__ == "__main__":
     AivenCLI().main()

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -3383,3 +3383,94 @@ class AivenClient(AivenClientBase):
             self.build_path("project", project, "secrets", "cmks", cmk_id, "service_associations"),
             result_key="service_associations",
         )
+
+    def upgrade_pipeline_step_create(
+        self,
+        organization_id: str,
+        source_project_name: str,
+        source_service_name: str,
+        destination_project_name: str,
+        destination_service_name: str,
+        auto_validation_delay_days: int | None,
+    ) -> Mapping:
+        return self.verify(
+            self.post,
+            self.build_path(
+                "organization",
+                organization_id,
+                "upgrade-pipeline",
+                "steps",
+            ),
+            body={
+                "source_project_name": source_project_name,
+                "source_service_name": source_service_name,
+                "destination_project_name": destination_project_name,
+                "destination_service_name": destination_service_name,
+                "auto_validation_delay_days": auto_validation_delay_days,
+            },
+        )
+
+    def upgrade_pipeline_step_update(
+        self, organization_id: str, step_id: str, auto_validation_delay_days: int | None
+    ) -> Mapping:
+        return self.verify(
+            self.patch,
+            self.build_path(
+                "organization",
+                organization_id,
+                "upgrade-pipeline",
+                "steps",
+                step_id,
+            ),
+            body={
+                "auto_validation_delay_days": auto_validation_delay_days,
+            },
+        )
+
+    def upgrade_pipeline_step_delete(self, organization_id: str, step_id: str) -> Mapping:
+        return self.verify(
+            self.delete,
+            self.build_path(
+                "organization",
+                organization_id,
+                "upgrade-pipeline",
+                "steps",
+                step_id,
+            ),
+        )
+
+    def upgrade_pipeline_step_get(self, organization_id: str, step_id: str) -> Mapping:
+        return self.verify(
+            self.get,
+            self.build_path(
+                "organization",
+                organization_id,
+                "upgrade-pipeline",
+                "steps",
+                step_id,
+            ),
+        )
+
+    def upgrade_pipeline_step_list(self, organization_id: str) -> Mapping:
+        return self.verify(
+            self.get,
+            self.build_path(
+                "organization",
+                organization_id,
+                "upgrade-pipeline",
+                "steps",
+            ),
+        )
+
+    def upgrade_pipeline_step_validate(self, project_name: str, service_name: str, comment: str | None) -> Mapping:
+        return self.verify(
+            self.post,
+            self.build_path(
+                "project",
+                project_name,
+                "service",
+                service_name,
+                "upgrade-validation",
+            ),
+            body={"comment": comment},
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -351,3 +351,165 @@ def test_refresh_service_privatelink_aws() -> None:
             params=None,
             data=None,
         )
+
+
+UPGRADE_STEP = {
+    "step_id": "3a718c8f-57cb-474e-a14f-8f5a7c63a751",
+    "source_project_name": "src-project",
+    "source_service_name": "src-service",
+    "destination_project_name": "dst-project",
+    "destination_service_name": "dst-service",
+    "auto_validation_delay_days": 7,
+    "last_validation": None,
+}
+
+
+def test_upgrade_pipeline_step_create() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "post") as post_mock:
+        post_mock.return_value = MockResponse(
+            status_code=HTTPStatus.OK,
+            headers={"Content-Type": "application/json"},
+            json_data=UPGRADE_STEP,
+        )
+
+        response = aiven_client.upgrade_pipeline_step_create(
+            organization_id="org123456789a",
+            source_project_name="src-project",
+            source_service_name="src-service",
+            destination_project_name="dst-project",
+            destination_service_name="dst-service",
+            auto_validation_delay_days=7,
+        )
+        assert response == UPGRADE_STEP
+
+        post_mock.assert_called_once_with(
+            "test_base_url/v1/organization/org123456789a/upgrade-pipeline/steps",
+            headers={"content-type": "application/json"},
+            params=None,
+            data=(
+                '{"source_project_name": "src-project", '
+                '"source_service_name": "src-service", '
+                '"destination_project_name": "dst-project", '
+                '"destination_service_name": "dst-service", '
+                '"auto_validation_delay_days": 7}'
+            ),
+        )
+
+
+def test_upgrade_pipeline_step_update() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "patch") as patch_mock:
+        patch_mock.return_value = MockResponse(
+            status_code=HTTPStatus.OK,
+            headers={"Content-Type": "application/json"},
+            json_data=UPGRADE_STEP,
+        )
+
+        response = aiven_client.upgrade_pipeline_step_update(
+            organization_id="org123456789a",
+            step_id="3a718c8f-57cb-474e-a14f-8f5a7c63a751",
+            auto_validation_delay_days=14,
+        )
+        assert response == UPGRADE_STEP
+
+        patch_mock.assert_called_once_with(
+            "test_base_url/v1/organization/org123456789a/upgrade-pipeline/steps/3a718c8f-57cb-474e-a14f-8f5a7c63a751",
+            headers={"content-type": "application/json"},
+            params=None,
+            data=('{"auto_validation_delay_days": 14}'),
+        )
+
+
+def test_upgrade_pipeline_step_delete() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "delete") as delete_mock:
+        delete_mock.return_value = MockResponse(
+            status_code=HTTPStatus.NO_CONTENT,
+            content=None,
+        )
+
+        response = aiven_client.upgrade_pipeline_step_delete(
+            organization_id="org123456789a",
+            step_id="3a718c8f-57cb-474e-a14f-8f5a7c63a751",
+        )
+        assert response == {}
+
+        delete_mock.assert_called_once_with(
+            "test_base_url/v1/organization/org123456789a/upgrade-pipeline/steps/3a718c8f-57cb-474e-a14f-8f5a7c63a751",
+            headers={"content-type": "application/octet-stream"},
+            params=None,
+            data=None,
+        )
+
+
+def test_upgrade_pipeline_step_get() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "get") as get_mock:
+        get_mock.return_value = MockResponse(
+            status_code=HTTPStatus.OK,
+            headers={"Content-Type": "application/json"},
+            json_data=UPGRADE_STEP,
+        )
+
+        response = aiven_client.upgrade_pipeline_step_get(
+            organization_id="org123456789a", step_id="3a718c8f-57cb-474e-a14f-8f5a7c63a751"
+        )
+        assert response == UPGRADE_STEP
+
+        get_mock.assert_called_once_with(
+            "test_base_url/v1/organization/org123456789a/upgrade-pipeline/steps/3a718c8f-57cb-474e-a14f-8f5a7c63a751",
+            headers={"content-type": "application/octet-stream"},
+            params=None,
+            data=None,
+        )
+
+
+def test_upgrade_pipeline_step_list() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "get") as get_mock:
+        get_mock.return_value = MockResponse(
+            status_code=HTTPStatus.OK,
+            headers={"Content-Type": "application/json"},
+            json_data={"steps": UPGRADE_STEP},
+        )
+
+        response = aiven_client.upgrade_pipeline_step_list(organization_id="org123456789a")
+        assert response == {"steps": UPGRADE_STEP}
+
+        get_mock.assert_called_once_with(
+            "test_base_url/v1/organization/org123456789a/upgrade-pipeline/steps",
+            headers={"content-type": "application/octet-stream"},
+            params=None,
+            data=None,
+        )
+
+
+def test_upgrade_pipeline_step_validate() -> None:
+    aiven_client = AivenClient("test_base_url")
+
+    with patch.object(aiven_client.session, "post") as post_mock:
+        post_mock.return_value = MockResponse(
+            status_code=HTTPStatus.OK,
+            headers={"Content-Type": "application/json"},
+            json_data=UPGRADE_STEP,
+        )
+
+        response = aiven_client.upgrade_pipeline_step_validate(
+            project_name="src-project",
+            service_name="src-service",
+            comment="validated",
+        )
+        assert response == UPGRADE_STEP
+
+        post_mock.assert_called_once_with(
+            "test_base_url/v1/project/src-project/service/src-service/upgrade-validation",
+            headers={"content-type": "application/json"},
+            params=None,
+            data='{"comment": "validated"}',
+        )


### PR DESCRIPTION
# About this change: What it does, why it matters

This adds aiven-client and CLI support for the new APIs that were added to TF provider in https://github.com/aiven/terraform-provider-aiven/commit/ea24be00a7478d8bf7cd0e9342c9e242fda79a4b


