### PR TITLE
avn: add "azure" as supported CMK provider

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -6796,7 +6796,7 @@ ssl.truststore.type=JKS
         self.print_response(rates, json=self.args.json, table_layout=layout)
 
     @arg.project
-    @arg("--provider", help="CMK cloud provider", choices=["aws", "gcp", "oci"], required=True)
+    @arg("--provider", help="CMK cloud provider", choices=["aws", "azure", "gcp", "oci"], required=True)
     @arg("--resource", help="Cloud provider key resource name (full resource path)", required=True)
     @arg("--default-cmk", action="store_true", default=False, help="Set as default CMK for all newly created services")
     @arg.json


### PR DESCRIPTION
# About this change: What it does, why it matters

Adds "azure" to the list of supported CMK providers when adding a CMK to a project 


