### PR TITLE
kafka: Make --partitions optional for topic-update command

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -2657,7 +2657,7 @@ ssl.truststore.type=JKS
     @arg.project
     @arg.service_name
     @arg.topic
-    @arg.partitions
+    @arg("--partitions", type=int, required=False, help="Number of partitions")
     @arg.min_insync_replicas
     @arg.retention
     @arg.retention_ms

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -408,6 +408,16 @@ def test_service_topic_create(command_line: str, expected_post_data: Mapping[str
                 "cleanup_policy": "compact",
             },
         ),
+        (
+            "service topic-update --project project1 --retention 168 service1 topic1",
+            {
+                "partitions": None,
+                "replication": None,
+                "min_insync_replicas": None,
+                "retention_bytes": None,
+                "retention_hours": 168,
+            },
+        ),
     ],
 )
 def test_service_topic_update(command_line: str, expected_put_data: Mapping[str, str | int | None]) -> None:


### PR DESCRIPTION
The shared arg.partitions definition has required=True, which makes sense for topic-create but not for topic-update where a user may only want to change retention, tags, or other config without specifying partitions. Use an inline arg definition with required=False, matching the existing pattern for --replication on the same command.


