### PR TITLE
perf: speed up `service create`

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -3927,10 +3927,14 @@ ssl.truststore.type=JKS
         return "Unknown {} {!r}{} (available options: {})".format(option_type, option, did_you_mean, ", ".join(options))
 
     def _get_service_type_user_config_schema(self, project: str, service_type: str) -> Mapping[str, Any]:
-        service_types = self.client.get_service_types(project=project)
         try:
-            service_def = service_types[service_type]
-        except KeyError as ex:
+            service_def = self.client.get_service_type(project=project, service_type=service_type)
+        except client.Error as ex:
+            if ex.status not in {HTTPStatus.BAD_REQUEST, HTTPStatus.NOT_FOUND}:
+                raise
+            # Unknown service type: fall back to the full catalog so we can offer
+            # a "did you mean" suggestion listing the available service types.
+            service_types = self.client.get_service_types(project=project)
             raise argx.UserError(
                 self._get_unknown_option_error(
                     option_type="service type",

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1678,6 +1678,15 @@ class AivenClient(AivenClientBase):
             path = self.build_path("project", project, "service_types")
         return self.verify(self.get, path, result_key="service_types")
 
+    def get_service_type(self, project: str, service_type: str) -> Mapping:
+        """Fetch a single service type definition.
+
+        Much cheaper than get_service_types(), which returns the full catalog
+        (tens of MB). Use this when only one service type's definition is needed.
+        """
+        path = self.build_path("project", project, "service-types", service_type)
+        return self.verify(self.get, path)
+
     def create_account(self, account_name: str) -> Mapping:
         body = {
             "account_name": account_name,

--- a/aiven/client/session.py
+++ b/aiven/client/session.py
@@ -32,11 +32,13 @@ def get_requests_session(*, timeout: int | None = None) -> Session:
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     session.verify = True
-    session.headers = CaseInsensitiveDict(
-        {
-            "content-type": "application/json",
-            "user-agent": "aiven-client/" + __version__,
-        }
+    session.headers.update(
+        CaseInsensitiveDict(
+            {
+                "content-type": "application/json",
+                "user-agent": "aiven-client/" + __version__,
+            }
+        )
     )
 
     return session


### PR DESCRIPTION
# Speed up `service create`

- use gzip compression
- query service catalog by service type i.e. use `/project/<project>/service-types/<service_type>` instead of `/project/<project>/service-types/<service_type>`, saving several MiB of data

For `avn service create my-valkey --cloud google-europe-west1 -p startup-4 -t valkey` this looks like:

```
  ┌──────────────────────┬─────────────────────────────┬────────────┐
  │       Version        │    service_types request    │ WALL total │
  ├──────────────────────┼─────────────────────────────┼────────────┤
  │ Baseline 4.12.0      │ ~5.2s / 24 MB               │ ~7.1s      │
  ├──────────────────────┼─────────────────────────────┼────────────┤
  │ + gzip               │ ~1.2s / 24 MB (wire 1.7 MB) │ ~2.9s      │
  ├──────────────────────┼─────────────────────────────┼────────────┤
  │ + gzip + single-type │ ~0.2s / 9 KB                │ ~1.4s      │
  └──────────────────────┴─────────────────────────────┴────────────┘
``` 


