### PR TITLE
Treat empty --user-config-json ("{}") as an explicit empty config

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -1994,7 +1994,7 @@ ssl.truststore.type=JKS
     @arg.json
     def service__integration_endpoint_create(self) -> None:
         """Create a service integration endpoint"""
-        if self.args.user_config_json:
+        if self.args.user_config_json is not None:
             user_config = self.args.user_config_json
         elif self.args.user_config:
             project = self.get_project()
@@ -2019,7 +2019,7 @@ ssl.truststore.type=JKS
     @arg.json
     def service__integration_endpoint_update(self) -> None:
         """Update a service integration endpoint"""
-        if self.args.user_config_json:
+        if self.args.user_config_json is not None:
             user_config = self.args.user_config_json
         elif self.args.user_config:
             project = self.get_project()
@@ -2095,7 +2095,7 @@ ssl.truststore.type=JKS
     @arg.json
     def service__integration_create(self) -> None:
         """Create a service integration"""
-        if self.args.user_config_json:
+        if self.args.user_config_json is not None:
             user_config = self.args.user_config_json
         elif self.args.user_config:
             project = self.get_project()
@@ -2123,7 +2123,7 @@ ssl.truststore.type=JKS
     @arg.json
     def service__integration_update(self) -> None:
         """Update a service integration"""
-        if self.args.user_config_json:
+        if self.args.user_config_json is not None:
             user_config = self.args.user_config_json
         elif self.args.user_config:
             project = self.get_project()

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -70,16 +70,19 @@ def user_config_json() -> Callable[[Callable[[CommandLineTool], T]], Callable[[C
         @wraps(fun)
         def wrapped(self: CommandLineTool) -> T:
             assert self.args is not None
-            if "user_config" in self.args and (self.args.user_config_json and self.args.user_config):
+            if "user_config" in self.args and self.args.user_config_json is not None and self.args.user_config:
                 raise UserError("-c (user config) and --user-config-json parameters can not be used at the same time")
-            try:
-                setattr(
-                    self.args,
-                    "user_config_json",
-                    get_json_config(self.args.user_config_json),
-                )
-            except jsonlib.decoder.JSONDecodeError as err:
-                raise UserError(f"Invalid user_config_json: {err!s}") from err
+            # Keep "not provided" (None) distinguishable from an explicitly
+            # empty config ("{}"), which must parse to an empty dict.
+            if self.args.user_config_json is not None:
+                try:
+                    setattr(
+                        self.args,
+                        "user_config_json",
+                        get_json_config(self.args.user_config_json),
+                    )
+                except jsonlib.decoder.JSONDecodeError as err:
+                    raise UserError(f"Invalid user_config_json: {err!s}") from err
             return fun(self)
 
         return wrapped

--- a/tests/test_cliarg.py
+++ b/tests/test_cliarg.py
@@ -74,6 +74,44 @@ def test_user_config_json_success() -> None:
     assert test_class.args.user_config_json == {"foo": "bar"}
 
 
+def test_user_config_json_not_provided_is_none() -> None:
+    """When --user-config-json is not provided, args.user_config_json is None.
+
+    This keeps "not provided" distinguishable from an explicitly empty
+    config (``--user-config-json "{}"``), which parses to ``{}``.
+    """
+
+    class T(CommandLineTool):
+        """Test class"""
+
+        @arg.user_config_json()
+        @arg()
+        def t(self) -> None:
+            """t"""
+
+    test_class = T("avn")
+    ret = test_class.run(args=["t"])
+    assert ret is None
+    assert test_class.args.user_config_json is None
+
+
+def test_user_config_json_explicit_empty_is_empty_dict() -> None:
+    """An explicit empty config parses to ``{}`` (not None)."""
+
+    class T(CommandLineTool):
+        """Test class"""
+
+        @arg.user_config_json()
+        @arg()
+        def t(self) -> None:
+            """t"""
+
+    test_class = T("avn")
+    ret = test_class.run(args=["t", "--user-config-json", "{}"])
+    assert ret is None
+    assert test_class.args.user_config_json == {}
+
+
 def test_user_config_success() -> None:
     """Test that user config parameter -c works and not cause conflict with
     --user_config_json


### PR DESCRIPTION
A missing flag and an explicit `"{}"` both collapsed to `{}`, and the
truthy call-site checks treated the empty dict as "not provided",
silently ignoring an intentionally-empty config. Gate parsing and all
call sites on `is not None` so an explicit empty config is honored.
