### PR TITLE
dev: document pyenv-virtualenv setup and ignore .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .venv/
+.python-version
 Pipfile*
 /.cache/
 *.pyc

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -13,6 +13,16 @@ After the local virtual environment is created, run the following to "shell in" 
 
     pipenv shell
 
+Alternatively, with ``pyenv`` and the ``pyenv-virtualenv`` plugin, create a project virtual environment and install all dependencies:
+
+::
+
+    pyenv virtualenv 3.13 aiven-client
+    pyenv local aiven-client
+    python -m pip install -e .[dev]
+
+``pyenv local`` writes a ``.python-version`` file that auto-activates the virtual environment when you enter the directory, provided ``eval "$(pyenv virtualenv-init -)"`` is in your shell startup.
+
 Releasing a new version
 =======================
 


### PR DESCRIPTION
## Summary
- Add a concise `pyenv` + `pyenv-virtualenv` development workflow to `DEVELOPMENT.rst`, mirroring the existing `pipenv` instructions.
- Ignore the `.python-version` file that `pyenv local` writes, since its value is specific to a local virtualenv name.

## Test plan
- [ ] `DEVELOPMENT.rst` renders correctly and the commands work end to end (`pyenv virtualenv`, `pyenv local`, `pip install -e .[dev]`).

Made with [Cursor](https://cursor.com)