### PR TITLE
client: bound HTTP keepalive connection reuse to mitigate timeout race

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 from . import argx, client, units
 from aiven.client import AivenClient, envdefault
 from aiven.client.cliarg import arg
-from aiven.client.client import Tag
+from aiven.client.client import DEFAULT_IDLE_TIMEOUT, DEFAULT_MAX_AGE, Tag
 from aiven.client.common import UNDEFINED
 from aiven.client.connection_info.common import Store
 from aiven.client.connection_info.kafka import KafkaCertificateConnectionInfo, KafkaSASLConnectionInfo
 from aiven.client.connection_info.pg import PGConnectionInfo
 from aiven.client.connection_info.valkey import ValkeyConnectionInfo
 from aiven.client.speller import suggest
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 from ast import literal_eval
 from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
@@ -139,8 +139,25 @@ def get_current_date() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def connection_lifetime_arg(value: str) -> float | None:
+    """Parse a connection idle-timeout/max-age argument, mapping -1 to None (disabled)."""
+    try:
+        parsed = float(value)
+    except ValueError:
+        raise ArgumentTypeError(f"invalid number of seconds: {value!r} (use -1 to disable)") from None
+    return None if parsed == -1 else parsed
+
+
 class ClientFactory(Protocol):
-    def __call__(self, base_url: str, show_http: bool, request_timeout: int | None) -> client.AivenClient: ...
+    def __call__(
+        self,
+        *,
+        base_url: str,
+        show_http: bool,
+        request_timeout: int | None,
+        idle_timeout: float | None,
+        max_age: float | None,
+    ) -> client.AivenClient: ...
 
 
 class AivenCLI(argx.CommandLineTool):
@@ -173,6 +190,18 @@ class AivenCLI(argx.CommandLineTool):
             type=int,
             default=None,
             help="Wait for up to N seconds for a response to a request (default: infinite)",
+        )
+        parser.add_argument(
+            "--idle-timeout",
+            type=connection_lifetime_arg,
+            default=DEFAULT_IDLE_TIMEOUT,
+            help="Recycle a pooled HTTP connection idle for more than N seconds, -1 to disable (default: %(default)s)",
+        )
+        parser.add_argument(
+            "--max-age",
+            type=connection_lifetime_arg,
+            default=DEFAULT_MAX_AGE,
+            help="Recycle a pooled HTTP connection older than N seconds, -1 to disable (default: %(default)s)",
         )
 
     def collect_user_config_options(self, obj_def: Mapping[str, Any], prefixes: list[str] | None = None) -> dict[str, Any]:
@@ -4525,6 +4554,8 @@ ssl.truststore.type=JKS
             base_url=self.args.url,
             show_http=self.args.show_http,
             request_timeout=self.args.request_timeout,
+            idle_timeout=self.args.idle_timeout,
+            max_age=self.args.max_age,
         )
         # Always set CA if we have anything set at the command line or in the env
         if self.args.auth_ca is not None:

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from ._typing import assert_never
 from .common import UNDEFINED
-from .session import get_requests_session
+from .session import DEFAULT_IDLE_TIMEOUT, DEFAULT_MAX_AGE, get_requests_session
 from collections.abc import Callable, Collection, Mapping, Sequence
 from http import HTTPStatus
 from requests import Response
@@ -91,12 +91,14 @@ class AivenClientBase:
         show_http: bool = False,
         request_timeout: int | None = None,
         default_retry_spec: RetrySpec = DEFAULT_RETRY,
+        idle_timeout: float | None = DEFAULT_IDLE_TIMEOUT,
+        max_age: float | None = DEFAULT_MAX_AGE,
     ) -> None:
         self.log = logging.getLogger("AivenClient")
         self.auth_token: str | None = None
         self.base_url = base_url
         self.log.debug("using %r", self.base_url)
-        self.session = get_requests_session(timeout=request_timeout)
+        self.session = get_requests_session(timeout=request_timeout, idle_timeout=idle_timeout, max_age=max_age)
         self.http_log = logging.getLogger("aiven_http")
         self.init_http_logging(show_http)
         self.api_prefix = "/v1"

--- a/aiven/client/session.py
+++ b/aiven/client/session.py
@@ -8,25 +8,68 @@ from requests import Session, adapters, models
 from requests.structures import CaseInsensitiveDict
 from typing import Any
 
+import time
+
 try:
     from .version import __version__
 except ImportError:
     __version__ = "UNKNOWN"
 
+# Recycle pooled connections so a connection the API server has already closed is
+# never written to (which would surface as a fatal RemoteDisconnected). The server
+# bounds how long it keeps a connection open, both while idle and by total
+# lifetime, so keep the client's reuse window below those. Two pool-wide bounds,
+# both checked before a request is sent and enforced via the public
+# PoolManager.clear():
+#  - idle timeout (50s): recycle a connection idle longer than this
+#  - max age (59m): recycle a connection older than this regardless of activity
+DEFAULT_IDLE_TIMEOUT = 50.0
+DEFAULT_MAX_AGE = 59 * 60.0
+
 
 class AivenClientAdapter(adapters.HTTPAdapter):
-    def __init__(self, *args: Any, timeout: int | None = None, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        timeout: int | None = None,
+        idle_timeout: float | None = None,
+        max_age: float | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.timeout = timeout
+        self.idle_timeout = idle_timeout
+        self.max_age = max_age
+        now = time.monotonic()
+        self._pools_created_at = now
+        self._last_used_at = now
         super().__init__(*args, **kwargs)
+
+    def _recycle_stale_connections(self) -> None:
+        now = time.monotonic()
+        recycle = (self.idle_timeout is not None and now - self._last_used_at >= self.idle_timeout) or (
+            self.max_age is not None and now - self._pools_created_at >= self.max_age
+        )
+        if recycle:
+            self.poolmanager.clear()
+            for proxy in self.proxy_manager.values():
+                proxy.clear()
+            self._pools_created_at = now
+        self._last_used_at = now
 
     def send(self, *args: Any, **kwargs: Any) -> models.Response:
         if not kwargs.get("timeout"):
             kwargs["timeout"] = self.timeout
+        self._recycle_stale_connections()
         return super().send(*args, **kwargs)
 
 
-def get_requests_session(*, timeout: int | None = None) -> Session:
-    adapter = AivenClientAdapter(timeout=timeout)
+def get_requests_session(
+    *,
+    timeout: int | None = None,
+    idle_timeout: float | None = DEFAULT_IDLE_TIMEOUT,
+    max_age: float | None = DEFAULT_MAX_AGE,
+) -> Session:
+    adapter = AivenClientAdapter(timeout=timeout, idle_timeout=idle_timeout, max_age=max_age)
 
     session = Session()
     session.mount("http://", adapter)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,8 +4,9 @@
 # See the file `LICENSE` for details.
 from __future__ import annotations
 
-from aiven.client.session import AivenClientAdapter, get_requests_session
+from aiven.client.session import DEFAULT_IDLE_TIMEOUT, DEFAULT_MAX_AGE, AivenClientAdapter, get_requests_session
 from requests import Session
+from typing import Any
 
 import pytest
 
@@ -22,6 +23,8 @@ def test_valid_requests_session() -> None:
     assert isinstance(adapter, AivenClientAdapter)
     assert hasattr(adapter, "timeout")
     assert adapter.timeout is None
+    assert adapter.idle_timeout == DEFAULT_IDLE_TIMEOUT
+    assert adapter.max_age == DEFAULT_MAX_AGE
 
 
 @pytest.mark.parametrize(
@@ -29,10 +32,15 @@ def test_valid_requests_session() -> None:
     [
         ("timeout", 30),
         ("timeout", 0),
+        ("idle_timeout", 10.0),
+        ("idle_timeout", None),
+        ("max_age", 120.0),
+        ("max_age", None),
     ],
 )
-def test_adapter_parameters_are_passed_along(argument: str, value: int) -> None:
-    session = get_requests_session(**{argument: value})
+def test_adapter_parameters_are_passed_along(argument: str, value: Any) -> None:
+    kwargs: dict[str, Any] = {argument: value}
+    session = get_requests_session(**kwargs)
     adapter = session.adapters["https://"]
     assert isinstance(adapter, AivenClientAdapter)
     assert hasattr(adapter, argument)


### PR DESCRIPTION
## Summary
- Recycle pooled HTTP keepalive connections in `AivenClientAdapter` before they outlive the API server's connection window, so the client never writes a request onto a connection the server has already closed (which surfaces as a fatal `RemoteDisconnected` and cannot be safely retried for non-idempotent methods).
- Two pool-wide bounds, checked before each request and enforced via the public `urllib3` `PoolManager.clear()` (no private APIs):
  - idle timeout (default 50s): recycle a connection idle longer than this.
  - max age (default 59m): recycle a connection older than this regardless of activity.
- Configurable via `get_requests_session()`, `AivenClient()`, and new `--idle-timeout` / `--max-age` CLI flags.
- Add tests for the new defaults and parameter passthrough.

## Notes
- Library API (`get_requests_session`, `AivenClient`) stays backwards-compatible; the only break is the internal `ClientFactory` extension point, which gains two parameters.
- Per-connection timers (like nginx-style idle/max-age) would require subclassing private `urllib3` pool internals; the pool-wide approach trades that fragility for coarser recycling, which is practically equivalent for this single-host, mostly-sequential CLI.

## Test plan
- [x] `make lint` (ruff check + format + mypy) passes.
- [x] `make test` passes (incl. new `tests/test_session.py` cases).

Made with [Cursor](https://cursor.com)