### PR TITLE
Add support for cross-region AWS privatelinks

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -869,10 +869,18 @@ class AivenCLI(argx.CommandLineTool):
     @arg("--format", help="Format string for output")
     @arg.json
     @arg("--principal", dest="principals", action="append", metavar="PRINCIPAL", help=_aws_privatelink_principal_help)
+    @arg(
+        "--supported-regions",
+        help="Comma-separated list of additional regions to allow connections from",
+        default=None,
+    )
     def service__privatelink__aws__create(self) -> None:
         """Create PrivateLink for a service"""
         resp = self.client.create_service_privatelink_aws(
-            project=self.get_project(), service=self.args.service_name, principals=self.args.principals
+            project=self.get_project(),
+            service=self.args.service_name,
+            principals=self.args.principals,
+            supported_regions=self.args.supported_regions.split(",") if self.args.supported_regions is not None else None,
         )
         self.print_response([resp], format=self.args.format, json=self.args.json)
 
@@ -881,10 +889,18 @@ class AivenCLI(argx.CommandLineTool):
     @arg("--format", help="Format string for output")
     @arg.json
     @arg("--principal", dest="principals", action="append", metavar="PRINCIPAL", help=_aws_privatelink_principal_help)
+    @arg(
+        "--supported-regions",
+        help="Comma-separated list of additional regions to allow connections from",
+        default=None,
+    )
     def service__privatelink__aws__update(self) -> None:
         """Update PrivateLink for a service"""
         resp = self.client.update_service_privatelink_aws(
-            project=self.get_project(), service=self.args.service_name, principals=self.args.principals
+            project=self.get_project(),
+            service=self.args.service_name,
+            principals=self.args.principals,
+            supported_regions=self.args.supported_regions.split(",") if self.args.supported_regions is not None else None,
         )
         self.print_response([resp], format=self.args.format, json=self.args.json)
 

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1465,13 +1465,23 @@ class AivenClient(AivenClientBase):
     def _privatelink_path(self, project: str, service: str, cloud_provider: str, *rest: str) -> str:
         return self.build_path("project", project, "service", service, "privatelink", cloud_provider, *rest)
 
-    def create_service_privatelink_aws(self, project: str, service: str, principals: Sequence[str]) -> Mapping:
+    def create_service_privatelink_aws(
+        self, project: str, service: str, principals: Sequence[str], supported_regions: Sequence[str] | None = None
+    ) -> Mapping:
         path = self._privatelink_path(project, service, "aws")
-        return self.verify(self.post, path, body={"principals": principals})
+        body = {"principals": principals}
+        if supported_regions is not None:
+            body["supported_regions"] = supported_regions
+        return self.verify(self.post, path, body=body)
 
-    def update_service_privatelink_aws(self, project: str, service: str, principals: Sequence[str]) -> Mapping:
+    def update_service_privatelink_aws(
+        self, project: str, service: str, principals: Sequence[str], supported_regions: Sequence[str] | None = None
+    ) -> Mapping:
         path = self._privatelink_path(project, service, "aws")
-        return self.verify(self.put, path, body={"principals": principals})
+        body = {"principals": principals}
+        if supported_regions is not None:
+            body["supported_regions"] = supported_regions
+        return self.verify(self.put, path, body=body)
 
     def delete_service_privatelink_aws(self, project: str, service: str) -> Mapping:
         path = self._privatelink_path(project, service, "aws")


### PR DESCRIPTION
# About this change: What it does, why it matters

This adds support for setting the list of additional supported regions for an AWS Privatelink service endpoint, if the feature is enabled.


