### PR TITLE
client: add support for kafka plugins

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -7143,6 +7143,216 @@ ssl.truststore.type=JKS
             project_name=project_name, service_name=self.args.service_name, comment=self.args.comment
         )
 
+    # ---- Kafka Connect custom plugins ----------------------------------------
+
+    def _resolve_kafka_plugin_file_id(self) -> str:
+        """Resolve a plugin file ID from --plugin-file-id or --plugin-name/--plugin-version."""
+        plugin_file_id = self.args.plugin_file_id
+        if plugin_file_id is not None:
+            return plugin_file_id
+        if not self.args.plugin_name or not self.args.plugin_version:
+            raise argx.UserError("Either --plugin-file-id or both --plugin-name and --plugin-version must be provided")
+        files = self.client.kafka_connect_custom_plugin_file_list(
+            organization_id=self.args.organization_id,
+            plugin_name=self.args.plugin_name,
+        )
+        matches = [f for f in files if f["plugin_version"] == self.args.plugin_version]
+        if not matches:
+            raise argx.UserError(
+                f"No plugin file found for plugin {self.args.plugin_name!r} version {self.args.plugin_version!r}"
+            )
+        return matches[0]["plugin_file_id"]
+
+    @arg.json
+    @arg.organization_id
+    @arg.kafka_connect_plugin_name
+    @arg("--plugin-version", required=True, help="Plugin version (semver, e.g. 2.7.14)")
+    @arg("--source", required=True, help="Path to the JAR or ZIP file to upload")
+    @arg(
+        "--content-type",
+        default="application/java-archive",
+        choices=["application/java-archive", "application/zip"],
+        help="MIME type of the plugin file (default: application/java-archive)",
+    )
+    @arg("--plugin-description", help="Human-readable description of the plugin (all versions)")
+    @arg("--file-description", help="Human-readable change notes for this version")
+    def organization__kafka_plugin__file__create(self) -> None:
+        """Create and upload a Kafka plugin file"""
+        if not os.path.isfile(self.args.source):
+            raise argx.UserError(f"Source file not found: {self.args.source!r}")
+        rsp = self.client.kafka_connect_custom_plugin_file_create(
+            organization_id=self.args.organization_id,
+            plugin_name=self.args.plugin_name,
+            plugin_version=self.args.plugin_version,
+            content_type=self.args.content_type,
+            plugin_description=self.args.plugin_description,
+            file_description=self.args.file_description,
+        )
+        upload_info = rsp.get("upload_info", {})
+        presigned_url = upload_info.get("url")
+        if not presigned_url:
+            raise argx.UserError("API did not return a presigned upload URL")
+
+        with open(self.args.source, "rb") as f:
+            put_response = requests.put(
+                presigned_url,
+                data=f,
+                headers={"Content-Type": self.args.content_type},
+                timeout=300,
+            )
+        if not put_response.ok:
+            raise argx.UserError(f"File upload failed: HTTP {put_response.status_code}: {put_response.text}")
+
+        safe_rsp = dict(rsp)
+        if isinstance(safe_rsp.get("upload_info"), dict):
+            safe_upload_info = dict(safe_rsp["upload_info"])
+            safe_upload_info.pop("url", None)
+            safe_rsp["upload_info"] = safe_upload_info
+        self.print_response(safe_rsp, json=self.args.json)
+
+    @arg.json
+    @arg.organization_id
+    @arg.kafka_connect_plugin_name
+    @arg("--plugin-description", required=True, help="New plugin description")
+    def organization__kafka_plugin__update(self) -> None:
+        """Update a Kafka Plugin description"""
+        self.print_response(
+            self.client.kafka_connect_custom_plugin_update(
+                organization_id=self.args.organization_id,
+                plugin_name=self.args.plugin_name,
+                plugin_description=self.args.plugin_description,
+            ),
+            json=self.args.json,
+        )
+
+    @arg.json
+    @arg.organization_id
+    @arg.kafka_connect_plugin_file_id
+    @arg("--file-description", required=True, help="New file description")
+    def organization__kafka_plugin__file__update(self) -> None:
+        """Update a Kafka Plugin file description"""
+        self.print_response(
+            self.client.kafka_connect_custom_plugin_file_update(
+                organization_id=self.args.organization_id,
+                plugin_file_id=self.args.plugin_file_id,
+                file_description=self.args.file_description,
+            ),
+            json=self.args.json,
+        )
+
+    @arg.organization_id
+    @arg("--plugin-file-id", help="Kafka Plugin file ID")
+    @arg("--plugin-name", help="Kafka Plugin name")
+    @arg("--plugin-version", help="Plugin version (e.g. 2.7.14)")
+    def organization__kafka_plugin__file__delete(self) -> None:
+        """Delete a Kafka Plugin file"""
+        plugin_file_id = self._resolve_kafka_plugin_file_id()
+        self.client.kafka_connect_custom_plugin_file_delete(
+            organization_id=self.args.organization_id,
+            plugin_file_id=plugin_file_id,
+        )
+
+    @arg.json
+    @arg.organization_id
+    def organization__kafka_plugin__list(self) -> None:
+        """List Kafka Plugins"""
+        self.print_response(
+            self.client.kafka_connect_custom_plugin_list(organization_id=self.args.organization_id),
+            json=self.args.json,
+            table_layout=["plugin_name", "plugin_description", "created_at"],
+        )
+
+    @arg.json
+    @arg.organization_id
+    @arg.kafka_connect_plugin_name
+    def organization__kafka_plugin__file__list(self) -> None:
+        """List Kafka Plugin files"""
+        self.print_response(
+            self.client.kafka_connect_custom_plugin_file_list(
+                organization_id=self.args.organization_id,
+                plugin_name=self.args.plugin_name,
+            ),
+            json=self.args.json,
+            table_layout=[
+                "plugin_file_id",
+                "plugin_version",
+                "file_description",
+                "file_status",
+                "created_at",
+                "verify_error_code",
+                "verify_error_message",
+            ],
+        )
+
+    @arg.json
+    @arg.organization_id
+    def organization__kafka_plugin__class__list(self) -> None:
+        """List Kafka Plugin classes"""
+        self.print_response(
+            self.client.kafka_connect_custom_plugin_class_list(organization_id=self.args.organization_id),
+            json=self.args.json,
+            table_layout=["plugin_class", "plugin_class_type", "title", "created_at"],
+        )
+
+    @arg.json
+    @arg.organization_id
+    @arg.kafka_connect_plugin_name
+    def organization__kafka_plugin__show(self) -> None:
+        """Show Kafka Plugin details"""
+        self.print_response(
+            [
+                self.client.kafka_connect_custom_plugin_get(
+                    organization_id=self.args.organization_id,
+                    plugin_name=self.args.plugin_name,
+                )
+            ],
+            json=self.args.json,
+            table_layout=["plugin_name", "plugin_description", "created_at"],
+        )
+
+    @arg.json
+    @arg.organization_id
+    @arg("--plugin-file-id", help="Kafka Plugin file ID")
+    @arg("--plugin-name", help="Kafka Plugin name")
+    @arg("--plugin-version", help="Plugin version (e.g. 2.7.14)")
+    def organization__kafka_plugin__file__show(self) -> None:
+        """Show Kafka Plugin file details"""
+        plugin_file_id = self._resolve_kafka_plugin_file_id()
+        self.print_response(
+            [
+                self.client.kafka_connect_custom_plugin_file_get(
+                    organization_id=self.args.organization_id,
+                    plugin_file_id=plugin_file_id,
+                )
+            ],
+            json=self.args.json,
+            table_layout=[
+                "plugin_file_id",
+                "plugin_version",
+                "file_description",
+                "file_status",
+                "created_at",
+                "verify_error_code",
+                "verify_error_message",
+            ],
+        )
+
+    @arg.json
+    @arg.organization_id
+    @arg.kafka_connect_plugin_class_name
+    def organization__kafka_plugin__class__show(self) -> None:
+        """Show Kafka Plugin class details"""
+        self.print_response(
+            [
+                self.client.kafka_connect_custom_plugin_class_get(
+                    organization_id=self.args.organization_id,
+                    plugin_class_name=self.args.plugin_class_name,
+                )
+            ],
+            json=self.args.json,
+            table_layout=["plugin_class", "plugin_class_type", "title", "created_at", "description", "author", "doc_url"],
+        )
+
 
 if __name__ == "__main__":
     AivenCLI().main()

--- a/aiven/client/cliarg.py
+++ b/aiven/client/cliarg.py
@@ -246,3 +246,9 @@ arg.tech_email = arg("--tech-email", action="append", help="Tech email address")
 arg.flink_application_id = arg("--application-id", required=True, help="Flink application id")
 arg.flink_application_version_id = arg("--application-version-id", required=True, help="Flink application version id")
 arg.flink_deployment_id = arg("--deployment-id", required=True, help="Flink deployment id")
+
+arg.kafka_connect_plugin_name = arg("--plugin-name", required=True, help="Kafka Connect custom plugin name")
+arg.kafka_connect_plugin_file_id = arg("--plugin-file-id", required=True, help="Kafka Connect custom plugin file ID")
+arg.kafka_connect_plugin_class_name = arg(
+    "--plugin-class-name", required=True, help="Fully-qualified Kafka Connect plugin class name"
+)

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -3503,3 +3503,103 @@ class AivenClient(AivenClientBase):
             ),
             body={"comment": comment},
         )
+
+    # ---- Kafka Connect custom plugins ----------------------------------------
+
+    def kafka_connect_custom_plugin_file_create(
+        self,
+        *,
+        organization_id: str,
+        plugin_name: str,
+        plugin_version: str,
+        service_type: str = "kafka_connect",
+        content_type: str = "application/java-archive",
+        plugin_description: str | None = None,
+        file_description: str | None = None,
+    ) -> Mapping:
+        body: dict[str, Any] = {
+            "plugin_name": plugin_name,
+            "plugin_version": plugin_version,
+            "service_type": service_type,
+            "content_type": content_type,
+        }
+        if plugin_description is not None:
+            body["plugin_description"] = plugin_description
+        if file_description is not None:
+            body["file_description"] = file_description
+        return self.verify(
+            self.post,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugin-files"),
+            body=body,
+        )
+
+    def kafka_connect_custom_plugin_file_update(
+        self,
+        *,
+        organization_id: str,
+        plugin_file_id: str,
+        file_description: str | None,
+    ) -> Mapping:
+        return self.verify(
+            self.put,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugin-files", plugin_file_id),
+            body={"file_description": file_description},
+        )
+
+    def kafka_connect_custom_plugin_file_delete(self, *, organization_id: str, plugin_file_id: str) -> Mapping:
+        return self.verify(
+            self.delete,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugin-files", plugin_file_id),
+        )
+
+    def kafka_connect_custom_plugin_file_get(self, *, organization_id: str, plugin_file_id: str) -> Mapping:
+        return self.verify(
+            self.get,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugin-files", plugin_file_id),
+        )
+
+    def kafka_connect_custom_plugin_file_list(self, *, organization_id: str, plugin_name: str) -> Sequence[dict[str, Any]]:
+        return self.verify(
+            self.get,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugins", plugin_name, "files"),
+            result_key="plugin_files",
+        )
+
+    def kafka_connect_custom_plugin_update(
+        self,
+        *,
+        organization_id: str,
+        plugin_name: str,
+        plugin_description: str | None,
+    ) -> Mapping:
+        return self.verify(
+            self.put,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugins", plugin_name),
+            body={"plugin_description": plugin_description},
+        )
+
+    def kafka_connect_custom_plugin_get(self, *, organization_id: str, plugin_name: str) -> Mapping:
+        return self.verify(
+            self.get,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugins", plugin_name),
+        )
+
+    def kafka_connect_custom_plugin_list(self, *, organization_id: str) -> Sequence[dict[str, Any]]:
+        return self.verify(
+            self.get,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugins"),
+            result_key="plugins",
+        )
+
+    def kafka_connect_custom_plugin_class_get(self, *, organization_id: str, plugin_class_name: str) -> Mapping:
+        return self.verify(
+            self.get,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugin-classes", plugin_class_name),
+        )
+
+    def kafka_connect_custom_plugin_class_list(self, *, organization_id: str) -> Sequence[dict[str, Any]]:
+        return self.verify(
+            self.get,
+            self.build_path("organization", organization_id, "kafka-connect", "custom-plugin-classes"),
+            result_key="plugin_classes",
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3467,3 +3467,413 @@ def test_inkless_offering_rates() -> None:
         cloud_provider="aws",
         cloud_name="aws-eu-north-1",
     )
+
+
+# ---- Kafka Connect custom plugins --------------------------------------------
+
+PLUGIN_FILE_ID = "543e420d-aa63-43e8-b8e8-294a78c600e7"
+PLUGIN_ID = "7f3e420d-aa63-43e8-b8e8-294a78c600e7"
+ORG_ID = "org4f9ed964ba9"
+
+CUSTOM_PLUGIN_FILE = {
+    "plugin_file_id": PLUGIN_FILE_ID,
+    "plugin_id": PLUGIN_ID,
+    "plugin_name": "my-connector",
+    "plugin_version": "2.7.14",
+    "file_status": "READY",
+    "file_description": None,
+    "file_sha256": "abc123",
+    "file_size": 1024,
+    "verify_error_code": None,
+    "verify_error_message": None,
+    "created_by": "user@example.com",
+    "updated_by": None,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+CUSTOM_PLUGIN = {
+    "plugin_id": PLUGIN_ID,
+    "plugin_name": "my-connector",
+    "service_type": "kafka_connect",
+    "plugin_description": "My connector",
+    "created_by": "user@example.com",
+    "updated_by": None,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+CUSTOM_PLUGIN_CLASS = {
+    "plugin_class": "io.example.MySourceConnector",
+    "plugin_class_type": "source",
+    "title": "My Source Connector",
+    "author": "Example Inc.",
+    "doc_url": None,
+    "description": None,
+    "created_by": "user@example.com",
+    "updated_by": None,
+    "created_at": "2026-01-01T00:00:00Z",
+    "updated_at": "2026-01-01T00:00:00Z",
+}
+
+
+def test_kafka_connect_custom_plugin_file_create(tmp_path: Any, capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    jar_file = tmp_path / "my-connector-2.7.14.jar"
+    jar_file.write_bytes(b"fake-jar-content")
+
+    aiven_client.kafka_connect_custom_plugin_file_create.return_value = {
+        **CUSTOM_PLUGIN_FILE,
+        "upload_info": {
+            "url": "https://s3.example.com/presigned-upload-url",
+            "content_type": "application/java-archive",
+            "max_file_size_bytes": 104857600,
+            "upload_expiry_seconds": 1200,
+        },
+    }
+
+    with mock.patch("requests.put") as mock_put:
+        mock_put.return_value = mock.Mock(ok=True, status_code=200)
+        build_aiven_cli(aiven_client).run(
+            args=[
+                "organization",
+                "kafka-plugin",
+                "file",
+                "create",
+                "--organization-id",
+                ORG_ID,
+                "--plugin-name",
+                "my-connector",
+                "--plugin-version",
+                "2.7.14",
+                "--source",
+                str(jar_file),
+                "--plugin-description",
+                "My connector",
+                "--file-description",
+                "Initial release",
+            ]
+        )
+
+    aiven_client.kafka_connect_custom_plugin_file_create.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_name="my-connector",
+        plugin_version="2.7.14",
+        content_type="application/java-archive",
+        plugin_description="My connector",
+        file_description="Initial release",
+    )
+    mock_put.assert_called_once()
+    _, put_kwargs = mock_put.call_args
+    assert put_kwargs["headers"]["Content-Type"] == "application/java-archive"
+    assert "presigned-upload-url" not in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_file_create_missing_source(tmp_path: Any) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+
+    result = build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "create",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+            "--plugin-version",
+            "2.7.14",
+            "--source",
+            str(tmp_path / "nonexistent.jar"),
+        ]
+    )
+
+    assert result == 1
+    aiven_client.kafka_connect_custom_plugin_file_create.assert_not_called()
+
+
+def test_kafka_connect_custom_plugin_update() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_update.return_value = CUSTOM_PLUGIN
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "update",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+            "--plugin-description",
+            "Updated description",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_update.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_name="my-connector",
+        plugin_description="Updated description",
+    )
+
+
+def test_kafka_connect_custom_plugin_file_update() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_file_update.return_value = CUSTOM_PLUGIN_FILE
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "update",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-file-id",
+            PLUGIN_FILE_ID,
+            "--file-description",
+            "Fixed memory leak",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_file_update.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_file_id=PLUGIN_FILE_ID,
+        file_description="Fixed memory leak",
+    )
+
+
+def test_kafka_connect_custom_plugin_file_delete() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_file_delete.return_value = {}
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "delete",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-file-id",
+            PLUGIN_FILE_ID,
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_file_delete.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_file_id=PLUGIN_FILE_ID,
+    )
+
+
+def test_kafka_connect_custom_plugin_file_delete_by_name_and_version() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_file_list.return_value = [CUSTOM_PLUGIN_FILE]
+    aiven_client.kafka_connect_custom_plugin_file_delete.return_value = {}
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "delete",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+            "--plugin-version",
+            "2.7.14",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_file_list.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_name="my-connector",
+    )
+    aiven_client.kafka_connect_custom_plugin_file_delete.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_file_id=PLUGIN_FILE_ID,
+    )
+
+
+def test_kafka_connect_custom_plugin_file_delete_missing_args() -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+
+    result = build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "delete",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+            # missing --plugin-version
+        ]
+    )
+    assert result == 1
+
+
+def test_kafka_connect_custom_plugin_list(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_list.return_value = [CUSTOM_PLUGIN]
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "list",
+            "--organization-id",
+            ORG_ID,
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_list.assert_called_once_with(organization_id=ORG_ID)
+    assert "my-connector" in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_file_list(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_file_list.return_value = [CUSTOM_PLUGIN_FILE]
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "list",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_file_list.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_name="my-connector",
+    )
+    assert PLUGIN_FILE_ID in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_class_list(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_class_list.return_value = [CUSTOM_PLUGIN_CLASS]
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "class",
+            "list",
+            "--organization-id",
+            ORG_ID,
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_class_list.assert_called_once_with(organization_id=ORG_ID)
+    assert "io.example.MySourceConnector" in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_get(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_get.return_value = CUSTOM_PLUGIN
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "show",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_get.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_name="my-connector",
+    )
+    assert "my-connector" in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_file_get(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_file_get.return_value = CUSTOM_PLUGIN_FILE
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "show",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-file-id",
+            PLUGIN_FILE_ID,
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_file_get.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_file_id=PLUGIN_FILE_ID,
+    )
+    assert PLUGIN_FILE_ID in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_file_show_by_name_and_version(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_file_list.return_value = [CUSTOM_PLUGIN_FILE]
+    aiven_client.kafka_connect_custom_plugin_file_get.return_value = CUSTOM_PLUGIN_FILE
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "file",
+            "show",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-name",
+            "my-connector",
+            "--plugin-version",
+            "2.7.14",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_file_list.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_name="my-connector",
+    )
+    aiven_client.kafka_connect_custom_plugin_file_get.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_file_id=PLUGIN_FILE_ID,
+    )
+    assert PLUGIN_FILE_ID in capsys.readouterr().out
+
+
+def test_kafka_connect_custom_plugin_class_get(capsys: CaptureFixture[str]) -> None:
+    aiven_client = mock.Mock(spec_set=AivenClient)
+    aiven_client.kafka_connect_custom_plugin_class_get.return_value = CUSTOM_PLUGIN_CLASS
+
+    build_aiven_cli(aiven_client).run(
+        args=[
+            "organization",
+            "kafka-plugin",
+            "class",
+            "show",
+            "--organization-id",
+            ORG_ID,
+            "--plugin-class-name",
+            "io.example.MySourceConnector",
+        ]
+    )
+
+    aiven_client.kafka_connect_custom_plugin_class_get.assert_called_once_with(
+        organization_id=ORG_ID,
+        plugin_class_name="io.example.MySourceConnector",
+    )
+    assert "io.example.MySourceConnector" in capsys.readouterr().out


### PR DESCRIPTION
Kafka plugins is a feature under limited availability (403 expected).

Added commands:
```
  avn organization kafka-plugin list
  avn organization kafka-plugin show   --organization-id --plugin-name
  avn organization kafka-plugin update --organization-id --plugin-name
                                       --plugin-description

  avn organization kafka-plugin file list   --organization-id --plugin-name
  avn organization kafka-plugin file show   --organization-id
                                            (--plugin-file-id |
                                             --plugin-name --plugin-version)
  avn organization kafka-plugin file create --organization-id --plugin-name
                                            --plugin-version --source
                                            [--content-type]
                                            [--plugin-description]
                                            [--file-description]
  avn organization kafka-plugin file update --organization-id --plugin-file-id
                                            --file-description
  avn organization kafka-plugin file delete --organization-id
                                            (--plugin-file-id |
                                             --plugin-name --plugin-version)

  avn organization kafka-plugin class list --organization-id
  avn organization kafka-plugin class show --organization-id
                                           --plugin-class-name
```