### PR TITLE
Remove legacy credits list avn command [AI-619]

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4894,15 +4894,6 @@ ssl.truststore.type=JKS
 
     @arg.json
     @arg.project
-    def credits__list(self) -> None:
-        """List claimed credits"""
-        project_name = self.get_project()
-        project_credits = self.client.list_project_credits(project=project_name)
-        layout = [["code", "remaining_value"]]
-        self.print_response(project_credits, json=self.args.json, table_layout=layout)
-
-    @arg.json
-    @arg.project
     @arg("--service", help="Related service name")
     @arg(
         "--severity",

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1956,13 +1956,6 @@ class AivenClient(AivenClientBase):
             result_key="events",
         )
 
-    def list_project_credits(self, project: str) -> Sequence[dict[str, Any]]:
-        return self.verify(
-            self.get,
-            self.build_path("project", project, "credits"),
-            result_key="credits",
-        )
-
     def start_service_maintenance(self, project: str, service: str) -> Mapping:
         return self.verify(
             self.put,


### PR DESCRIPTION
## Summary

- Remove `credits list` command from `avn`.
- Remove `list_project_credits` client method that calls `GET /v1/project/{project}/credits` (deprecated API, sunset 2026-08-15).

Project-level credits listing is replaced by org billing-group scoped APIs. There is no sensible migration path for this legacy CLI command.

## Out of scope

- New org/billing-group credits CLI (future work; use Console or REST APIs for now)
- `billing-group credits-*` commands (removed separately in AI-618 / PR #474)

## Test plan

- [x] `python3 -m pytest tests/ -q` (242 passed)
- [x] `avn help` no longer lists `credits` commands

Jira: https://aiven.atlassian.net/browse/AI-619
Related: https://aiven.atlassian.net/browse/AI-618, https://aiven.atlassian.net/browse/AI-553

Made with [Cursor](https://cursor.com)