### PR TITLE
Remove sunset project user management avn commands [AI-621]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,18 +182,6 @@ Delete an empty project::
 
   $ avn project delete myproject
 
-List authorized users in a project::
-
-  $ avn project user-list
-
-Invite an existing Aiven user to a project::
-
-  $ avn project user-invite somebody@example.com
-
-Remove a user from the project::
-
-  $ avn project user-remove somebody@example.com
-
 View project management event log::
 
   $ avn events

--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -4424,64 +4424,6 @@ ssl.truststore.type=JKS
         with open(self.args.target_filepath, "w", encoding="utf-8") as fp:
             fp.write(result["certificate"])
 
-    @arg.project
-    @arg.email
-    @arg(
-        "--role",
-        help="Project role for new invited user ('admin', 'operator', 'developer')",
-    )
-    def project__user_invite(self) -> None:
-        """Invite a new user to the project"""
-        project_name = self.get_project()
-        try:
-            self.client.invite_project_user(
-                project=project_name,
-                user_email=self.args.email,
-                member_type=self.args.role,
-            )
-        except client.Error as ex:
-            print(ex.response.text)
-            raise argx.UserError("Project '{}' invite for {} failed".format(project_name, self.args.email))
-        self.log.info("Invited %r into project %r", self.args.email, project_name)
-
-    @arg.project
-    @arg.email
-    def project__user_remove(self) -> None:
-        """Remove a user from the project"""
-        project_name = self.get_project()
-        try:
-            self.client.remove_project_user(project=project_name, user_email=self.args.email)
-        except client.Error as ex:
-            print(ex.response.text)
-            raise argx.UserError("Project '{}' removal of user {} failed".format(project_name, self.args.email))
-        self.log.info("Removed %r from project %r", self.args.email, project_name)
-
-    @arg.json
-    @arg.project
-    def project__user_list(self) -> None:
-        """Project user list"""
-        project_name = self.get_project()
-        try:
-            user_list = self.client.list_project_users(project=project_name)
-            layout = [["user_email", "member_type", "create_time"]]
-            self.print_response(user_list, json=self.args.json, table_layout=layout)
-        except client.Error as ex:
-            print(ex.response.text)
-            raise argx.UserError("Project user listing for '{}' failed".format(project_name))
-
-    @arg.json
-    @arg.project
-    def project__invite_list(self) -> None:
-        """Project user list"""
-        project_name = self.get_project()
-        try:
-            user_list = self.client.list_invited_project_users(project=project_name)
-            layout = [["invited_user_email", "inviting_user_email", "member_type", "invite_time"]]
-            self.print_response(user_list, json=self.args.json, table_layout=layout)
-        except client.Error as ex:
-            print(ex.response.text)
-            raise argx.UserError("Project user listing for '{}' failed".format(project_name))
-
     def _print_tags(self, tags: Mapping[str, Any]) -> None:
         layout = [["key", "value"]]
         self.print_response(

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -1786,23 +1786,6 @@ class AivenClient(AivenClientBase):
     def get_project_ca(self, project: str) -> Mapping:
         return self.verify(self.get, self.build_path("project", project, "kms", "ca"))
 
-    def invite_project_user(self, project: str, user_email: str, member_type: str | None = None) -> Mapping:
-        body = {
-            "user_email": user_email,
-        }
-        if member_type is not None:
-            body["member_type"] = member_type
-        return self.verify(self.post, self.build_path("project", project, "invite"), body=body)
-
-    def remove_project_user(self, project: str, user_email: str) -> Mapping:
-        return self.verify(self.delete, self.build_path("project", project, "user", user_email))
-
-    def list_project_users(self, project: str) -> Sequence[dict[str, Any]]:
-        return self.verify(self.get, self.build_path("project", project, "users"), result_key="users")
-
-    def list_invited_project_users(self, project: str) -> Sequence[dict[str, Any]]:
-        return self.verify(self.get, self.build_path("project", project, "users"), result_key="invitations")
-
     def create_user(self, email: str, password: str | None, real_name: str, *, tenant: str | None = None) -> Mapping:
         request = {
             "email": email,


### PR DESCRIPTION
## Summary

- Remove the four `project` user-management subcommands that call APIs past their 2026-07-21 sunset date: `invite-list`, `user-invite`, `user-list`, `user-remove`.
- Remove the corresponding client methods (`invite_project_user`, `remove_project_user`, `list_project_users`, `list_invited_project_users`).
- Drop README examples for the removed commands.

Deprecated project CRUD commands (`create`, `delete`, `details`, `list`, `switch`, `update`) are intentionally kept until their 2027-01-31 sunset.

## Test plan

- [x] `python3 -m pytest tests/ -q` (242 passed)
- [x] `avn help` no longer lists `project user-*` or `project invite-list`

Jira: https://aiven.atlassian.net/browse/AI-621
Related: https://aiven.atlassian.net/browse/AI-553

Made with [Cursor](https://cursor.com)