### PR TITLE
Migrate org VPC user-peer-network-cidrs to new API [AI-601]

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5754,29 +5754,35 @@ ssl.truststore.type=JKS
 
     @arg("--organization-id", required=True, help="Identifier of the organization of the custom cloud environment")
     @arg("--organization-vpc-id", required=True)
-    @arg("--peering-connection-id", required=True)
+    @arg("--peer-cloud-account", required=True, help=_peer_cloud_account_help)
+    @arg("--peer-resource-group", help=_peer_resource_group_help)
+    @arg("--peer-vpc", required=True, help=_peer_vpc_help)
     @arg("cidrs", nargs="+", metavar="CIDR")
     @arg.json
     def organization__vpc__peering_connection__user_peer_network_cidrs__add(self) -> None:
-        """Add user peer network CIDRs for an organization VPC peering connection."""
+        """Add user peer network CIDRs for an organization VPC."""
+        add_base = {
+            "peer_cloud_account": self.args.peer_cloud_account,
+            "peer_vpc": self.args.peer_vpc,
+        }
+        if self.args.peer_resource_group is not None:
+            add_base["peer_resource_group"] = self.args.peer_resource_group
+        add = [dict(add_base, cidr=cidr) for cidr in self.args.cidrs]
         self.client.organization_vpc_user_peer_network_cidrs_update(
             organization_id=self.args.organization_id,
             organization_vpc_id=self.args.organization_vpc_id,
-            peering_connection_id=self.args.peering_connection_id,
-            add=[{"cidr": cidr} for cidr in self.args.cidrs],
+            add=add,
         )
 
     @arg("--organization-id", required=True, help="Identifier of the organization of the custom cloud environment")
     @arg("--organization-vpc-id", required=True)
-    @arg("--peering-connection-id", required=True)
     @arg("cidrs", nargs="+", metavar="CIDR")
     @arg.json
     def organization__vpc__peering_connection__user_peer_network_cidrs__delete(self) -> None:
-        """Delete user peer network CIDRs from an organization VPC peering connection."""
+        """Delete user peer network CIDRs from an organization VPC."""
         self.client.organization_vpc_user_peer_network_cidrs_update(
             organization_id=self.args.organization_id,
             organization_vpc_id=self.args.organization_vpc_id,
-            peering_connection_id=self.args.peering_connection_id,
             delete=self.args.cidrs,
         )
 

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2897,17 +2897,14 @@ class AivenClient(AivenClientBase):
         *,
         organization_id: str,
         organization_vpc_id: str,
-        peering_connection_id: str,
         add: Sequence[Mapping[str, str]] | None = None,
         delete: Sequence[str] | None = None,
     ) -> Mapping[Any, Any]:
         path = self.build_path(
             "organization",
             organization_id,
-            "vpcs",
+            "vpc",
             organization_vpc_id,
-            "peering-connections",
-            peering_connection_id,
             "user-peer-network-cidrs",
         )
         body: dict[str, Any] = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2867,16 +2867,23 @@ def test_organization_vpc_peering_connection_user_peer_network_cidrs_add() -> No
         "org4f9ed964ba9",
         "--organization-vpc-id",
         "58e00a73-61c7-470d-b140-ace64c21a417",
-        "--peering-connection-id",
-        "peering-connection-id",
+        "--peer-cloud-account",
+        "123456789012",
+        "--peer-vpc",
+        "vpc-2f09a348",
         "11.0.0.0/24",
     ]
     build_aiven_cli(aiven_client).run(args=args)
     aiven_client.organization_vpc_user_peer_network_cidrs_update.assert_called_once_with(
         organization_id="org4f9ed964ba9",
         organization_vpc_id="58e00a73-61c7-470d-b140-ace64c21a417",
-        peering_connection_id="peering-connection-id",
-        add=[{"cidr": "11.0.0.0/24"}],
+        add=[
+            {
+                "peer_cloud_account": "123456789012",
+                "peer_vpc": "vpc-2f09a348",
+                "cidr": "11.0.0.0/24",
+            }
+        ],
     )
 
 
@@ -2893,15 +2900,12 @@ def test_organization_vpc_peering_connection_user_peer_network_cidrs_delete() ->
         "org4f9ed964ba9",
         "--organization-vpc-id",
         "58e00a73-61c7-470d-b140-ace64c21a417",
-        "--peering-connection-id",
-        "peering-connection-id",
         "11.0.0.0/24",
     ]
     build_aiven_cli(aiven_client).run(args=args)
     aiven_client.organization_vpc_user_peer_network_cidrs_update.assert_called_once_with(
         organization_id="org4f9ed964ba9",
         organization_vpc_id="58e00a73-61c7-470d-b140-ace64c21a417",
-        peering_connection_id="peering-connection-id",
         delete=["11.0.0.0/24"],
     )
 


### PR DESCRIPTION
## Summary

- Migrate `organization vpc peering-connection user-peer-network-cidrs add/delete` to the VPC-level replacement API.
- Update `organization_vpc_user_peer_network_cidrs_update()` to call `PUT /v1/organization/{org_id}/vpc/{vpc_id}/user-peer-network-cidrs` instead of the sunset per-peering-connection path.
- Remove `--peering-connection-id` from the CLI; the old path parameter was ignored by the server.

The per-peering-connection endpoint was sunset on 2026-04-30. Request body semantics are unchanged (`add` / `delete`).

## Test plan

- [x] `python3 -m pytest tests/ -q` (242 passed)
- [x] `python3 -m pytest tests/test_cli.py -k organization_vpc_peering_connection_user_peer -q`

Jira: https://aiven.atlassian.net/browse/AI-601