### PR TITLE
Remove sunset sustainability avn commands [AI-624]

### DIFF
--- a/aiven/client/cli.py
+++ b/aiven/client/cli.py
@@ -5780,45 +5780,6 @@ ssl.truststore.type=JKS
             delete=self.args.cidrs,
         )
 
-    @arg.project
-    @arg.cloud
-    @arg.json
-    @arg.service_type
-    @arg("-p", "--plan", help="subscription plan of service")
-    def sustainability__service_plan_emissions_project(self) -> None:
-        """Estimate emissions for a service plan"""
-        project = self.get_project()
-        service_type = self._get_service_type()
-        plan = self._get_plan()
-        cloud = self.args.cloud
-
-        estimate = self.client.sustainability_service_plan_emissions_project(
-            project=project, service_type=service_type, plan=plan, cloud=cloud
-        )
-        records = [{"measurement": k, "value": v} for k, v in estimate["emissions"].items()]
-
-        layout = ["measurement", "value"]
-
-        self.print_response(records, json=self.args.json, table_layout=layout)
-
-    @arg.project
-    @arg.json
-    @arg("--since", help="Period begin datestamp in format YYYYMMDD", required=True)
-    @arg("--until", help="Period begin datestamp in format YYYYMMDD", required=True)
-    def sustainability__project_emissions_estimate(self) -> None:
-        """Estimate emissions for a project"""
-        project = self.get_project()
-        since = self.args.since
-        until = self.args.until
-
-        estimate = self.client.sustainability_project_emissions_estimate(project=project, since=since, until=until)
-
-        records = [{"measurement": k, "value": v} for k, v in estimate["emissions"].items()]
-
-        layout = ["measurement", "value"]
-
-        self.print_response(records, json=self.args.json, table_layout=layout)
-
     @arg("--organization-id", required=True, help="Identifier of the organization of the custom cloud environment")
     @arg("--deployment-model", required=True, help="Deployment model for the BYOC cloud")
     @arg("--cloud-provider", required=True, help="Cloud provider to create the BYOC cloud in")

--- a/aiven/client/client.py
+++ b/aiven/client/client.py
@@ -2492,38 +2492,6 @@ class AivenClient(AivenClientBase):
             self.build_path("organization", organization_id, "user-groups", group_id),
         )
 
-    def sustainability_service_plan_emissions_project(
-        self, project: str, service_type: str, plan: str, cloud: str
-    ) -> dict[str, Any]:
-        return self.verify(
-            self.get,
-            self.build_path(
-                "project",
-                project,
-                "sustainability",
-                "emissions-project",
-                "service-types",
-                service_type,
-                "plans",
-                plan,
-                "clouds",
-                cloud,
-            ),
-        )
-
-    def sustainability_project_emissions_estimate(self, project: str, since: str, until: str) -> dict[str, Any]:
-        params = {"since": since, "until": until}
-        return self.verify(
-            self.get,
-            self.build_path(
-                "project",
-                project,
-                "sustainability",
-                "emissions",
-            ),
-            params=params,
-        )
-
     def byoc_create(
         self,
         *,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1925,45 +1925,6 @@ def test_custom_files_update(capsys: CaptureFixture[str]) -> None:
     assert json.loads(captured.out.strip()) == return_value
 
 
-def test_sustainability__service_plan_emissions_project() -> None:
-    aiven_client = mock.Mock(spec_set=AivenClient)
-    aiven_client.sustainability_service_plan_emissions_project.return_value = {
-        "emissions": {"co2eq_mtons": "0.25", "energy_kwh": "639.50"}
-    }
-    args = [
-        "sustainability",
-        "service-plan-emissions-project",
-        "--project=myproj",
-        "--service-type=kafka",
-        "--plan=business-32",
-        "--cloud=google-europe-west1",
-    ]
-    build_aiven_cli(aiven_client).run(args=args)
-    aiven_client.sustainability_service_plan_emissions_project.assert_called_with(
-        project="myproj", service_type="kafka", plan="business-32", cloud="google-europe-west1"
-    )
-
-
-def test_sustainability__project_emissions_estimate() -> None:
-    aiven_client = mock.Mock(spec_set=AivenClient)
-    aiven_client.sustainability_project_emissions_estimate.return_value = {
-        "emissions": {"co2eq_mtons": "0.50", "energy_kwh": "1279.00"}
-    }
-    args = [
-        "sustainability",
-        "project-emissions-estimate",
-        "--project=myproj",
-        "--since=20230901",
-        "--until=20231001",
-    ]
-    build_aiven_cli(aiven_client).run(args=args)
-    aiven_client.sustainability_project_emissions_estimate.assert_called_with(
-        project="myproj",
-        since="20230901",
-        until="20231001",
-    )
-
-
 def test_byoc_create() -> None:
     aiven_client = mock.Mock(spec_set=AivenClient)
     aiven_client.byoc_create.return_value = {


### PR DESCRIPTION
## Summary

- Remove both `sustainability` subcommands that call project-level APIs past their 2026-04-10 sunset date: `service-plan-emissions-project` and `project-emissions-estimate`.
- Remove corresponding client methods and tests.

These APIs are already hollowed in Acorn (410). Org-level emissions (`GET /organization/{org_id}/emissions`) is a different model — no CLI migration planned.

## Test plan

- [x] `python3 -m pytest tests/ -q` (240 passed)
- [x] Rebased onto current main (includes #474–#477, #475)

Jira: https://aiven.atlassian.net/browse/AI-624

Made with [Cursor](https://cursor.com)